### PR TITLE
set_dimension_names and load file on init

### DIFF
--- a/coast/ALTIMETRY.py
+++ b/coast/ALTIMETRY.py
@@ -6,27 +6,13 @@ import xarray as xa
 
 
 class ALTIMETRY(OBSERVATION):
-
-    def __init__(self):
-        super()
-        self.sla_filtered = None
-        self.sla_unfiltered = None
-        self.mdt = None
-        self.ocean_tide = None
-        self.latitude = None
-        self.longitude = None
-        self.time = None
-        # List of variables that are actually in the object (successfully read)
-        self.var_list = []
-        # Mapping of quick access variables to dataset variables
-        # {'referencing_var' : 'dataset_var'}.
-        self.var_dict = {'sla_filtered'   : 'sla_filtered',
-                         'sla_unfiltered' : 'sla_unfiltered',
-                         'mdt'            : 'mdt',
-                         'ocean_tide'     : 'ocean_tide',
-                         'longitude'      : 'longitude', 
-                         'latitude'       : 'latitude',
-                         'time'           : 'time'}
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        return
+    
+    def set_dimension_mapping(self):
+        self.dim_mapping = None
 
     def set_command_variables(self):
         """

--- a/coast/ALTIMETRY.py
+++ b/coast/ALTIMETRY.py
@@ -13,17 +13,6 @@ class ALTIMETRY(OBSERVATION):
     
     def set_dimension_mapping(self):
         self.dim_mapping = None
-
-    def set_command_variables(self):
-        """
-         A method to make accessing the following simpler
-        """
         
-        for key, value in self.var_dict.items():
-            try:
-                setattr( self, key, self.dataset[value] )
-                self.var_list.append(key)
-            except AttributeError as e:
-                warn(str(e))
-                
-        self.adjust_longitudes()
+    def set_variable_mapping(self):
+        self.var_mapping = None

--- a/coast/COAsT.py
+++ b/coast/COAsT.py
@@ -11,22 +11,45 @@ def setup_dask_clinet(workers=2, threads=2, memory_limit_per_worker='2GB'):
 
 
 class COAsT:
-    def __init__(self, workers=2, threads=2, memory_limit_per_worker='2GB'):
+    def __init__(self, file = None, chunks: dict=None, multiple=False,
+                 workers=2, threads=2, memory_limit_per_worker='2GB'):
         # self.client = Client(n_workers=workers, threads_per_worker=threads, memory_limit=memory_limit_per_worker)
         self.dataset = None
-        # Radius of the earth in km
-        self.earth_raids = 6371.007176
-        
-    def copy(self):
-        return copy.copy(self)
+        self.earth_raids = 6371.007176 # Radius of the earth in km
+        self.set_dimension_mapping()
+        self.load(file, chunks, multiple)
 
-    def load(self, file, chunks: dict = None):
+    def load(self, file_or_dir, chunks:dict=None, multiple=False):
+        """
+        Loads a file into a COAsT object's dataset variable using xarray
+        
+        Args:
+            file (str)     : file name or directory to multiple files.
+            chunks (dict)  : Chunks to use in Dask [default None]
+            multiple (bool): If true, load in multiple files from directory.
+                             If false load a single file [default False]
+        """
+        if file_or_dir is not None:
+            if multiple:
+                self.load_multiple(file_or_dir, chunks)
+            else:
+                self.load_single(file_or_dir, chunks)    
+        else:
+            print("No file or directory specified: " + str(self) + " \n" +
+                  "Use COAsT.load() to load a netCDF file from file path or " +
+                  " directory into this object.")
+
+    def load_single(self, file, chunks: dict = None):
+        """ Loads a single file into COAsT object's dataset variable. """
         self.dataset = xr.open_dataset(file, chunks=chunks)
+        self.set_dimension_names(self.dim_mapping)
 
     def load_multiple(self, directory_to_files, chunks: dict = None):
+        """ Loads multiple files from directory into dataset variable. """
         self.dataset = xr.open_mfdataset(
-            directory_to_files, chunks=chunks, parallel=True, combine="by_coords", compat='override'
-        )
+            directory_to_files, chunks=chunks, parallel=True, 
+            combine="by_coords", compat='override')
+        self.set_dimension_names(self.dim_mapping)
         
     def load_dataset(self, dataset):
         """        
@@ -35,6 +58,28 @@ class COAsT:
         """
         
         self.dataset = dataset
+    
+    def set_dimension_mapping(self):
+        self.dim_mapping = None
+        
+    def set_dimension_names(self, dim_mapping: dict):
+        """ 
+        Relabel dimensions in COAsT object xarray.dataset to ensure
+        consistent naming throughout the COAsT package.
+        
+        Args:
+            dim_mapping (dict): keys are dimension names to change and values
+                                new dimension names
+        """
+        if dim_mapping is None: return
+        for key, value in dim_mapping.items():
+            try:
+                self.dataset = self.dataset.rename_dims({ key : value })
+            except:
+                print(str(self) + ': Problem mapping ' + key + ' to ' + value)
+        
+    def copy(self):
+        return copy.copy(self)
         
     def isel(self, indexers: dict = None, drop: bool = False,
              **kwargs):

--- a/coast/DOMAIN.py
+++ b/coast/DOMAIN.py
@@ -11,8 +11,9 @@ class DOMAIN(COAsT):
         return
 
     def set_dimension_mapping(self):
-        self.dim_mapping = {'t':'t_dim', 'z':'z_dim', 
-                            'y':'y_dim', 'x':'x_dim'}
+        #self.dim_mapping = {'t':'t_dim', 'z':'z_dim', 
+        #                    'y':'y_dim', 'x':'x_dim'}
+        self.dim_mapping = None
 
     def subset_indices_by_distance(self, centre_lon, centre_lat, radius):
         """

--- a/coast/DOMAIN.py
+++ b/coast/DOMAIN.py
@@ -6,83 +6,13 @@ import xarray as xa
 
 class DOMAIN(COAsT):
 
-    def __init__(self):
-        super()
-        self.bathy_metry = None
-        self.nav_lat = None
-        self.nav_lon = None
-        self.e1u = None
-        self.e1v = None
-        self.e1t = None
-        self.e1f = None
-        self.e2u = None
-        self.e2v = None
-        self.e2t = None
-        self.e2f = None
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        return
 
-    def set_command_variables(self):
-        """
-         A method to make accessing the following simpler
-                bathy_metry (t,y,x) - float - (m i.e. metres)
-                nav_lat (y,x) - float - (deg)
-                nav_lon (y,x) - float - (deg)
-                e1u, e1v, e1t, e1f (t,y,x) - double - (m)
-                e2u, e2v, e2t, e2f (t,y,x) - double - (m)
-        """
-        try:
-            self.bathy_metry = self.dataset.bathy_metry
-        except AttributeError as e:
-            warn(str(e))
-
-        try:
-            self.nav_lat = self.dataset.nav_lat
-        except AttributeError as e:
-            warn(str(e))
-
-        try:
-            self.nav_lon = self.dataset.nav_lon
-        except AttributeError as e:
-            warn(str(e))
-
-        try:
-            self.e1u = self.dataset.e1u
-        except AttributeError as e:
-            warn(str(e))
-
-        try:
-            self.e1v = self.dataset.e1v
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e1t = self.dataset.e1t
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e1f = self.dataset.e1f
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e2u = self.dataset.e2u
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e2v = self.dataset.e2v
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e2t = self.dataset.e2t
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e2f = self.dataset.e2f
-        except AttributeError as e:
-            print(str(e))
+    def set_dimension_mapping(self):
+        self.dim_mapping = {'t':'t_dim', 'z':'z_dim', 
+                            'y':'y_dim', 'x':'x_dim'}
 
     def subset_indices_by_distance(self, centre_lon, centre_lat, radius):
         """

--- a/coast/DOMAIN.py
+++ b/coast/DOMAIN.py
@@ -60,8 +60,8 @@ class DOMAIN(COAsT):
         
         return: Indices corresponding to datapoints inside specified box
         """
-        lon = self.nav_lon.copy()
-        lat = self.nav_lat
+        lon = self.dataset.nav_lon.copy()
+        lat = self.dataset.nav_lat
         ff1 = ( lon > lonbounds[0] ).astype(int)
         ff2 = ( lon < lonbounds[1] ).astype(int)
         ff3 = ( lat > latbounds[0] ).astype(int)

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -8,95 +8,13 @@ from .interpolate_along_dimension import interpolate_along_dimension
 import matplotlib.pyplot as plt
 
 class NEMO(COAsT):
-
-    def __init__(self):
-        super()
-        self.ssh = None
-        self.nav_lat = None
-        self.nav_lon = None
-        self.botpres = None
-        self.toce = None
-        self.soce = None
-        self.e3t = None
-        self.e3u = None
-        self.e3v = None
-        self.uoce = None
-        self.voce = None
-        self.utau = None
-        self.vtau = None
-
-    def set_command_variables(self):
-        """ A method to make accessing the following simpler
-                ssh (t,y,x) - sea surface height above geoid - (m)
-                botpres (t,y,x) - sea water pressure at sea ﬂoor - (dbar)
-                toce (t,z,y,x) -  sea water potential temperature -  (degC)
-                soce (t,z,y,x) - sea water practical salinity - (degC)
-                e3t (t,z,y,x) - T-cell thickness - (m)
-                e3u (t,z,y,x) - U-cell thickness - (m)
-                e3v (t,z,y,x) - V-cell thickness - (m)
-                uoce (t,z,y,x) - sea water x-velocity (m/s)
-                voce (t,z,y,x) - sea water y-velocity (m/s)
-                utau(t,y,x) - wind stress x (N/m2)
-                vtau(t,y,x) - wind stress y (N/m2)
-        """
-        try:
-            self.nav_lon = self.dataset.nav_lon
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.nav_lat = self.dataset.nav_lat
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.ssh = self.dataset.sossheig
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.botpres = self.dataset.botpres
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.toce = self.dataset.voctemper
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.soce = self.dataset.soce
-        except AttributeError as e:
-            print(str(e))
-
-        try:
-            self.e3t = self.dataset.e3t
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.e3u = self.dataset.e3u
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.e3v = self.dataset.e3v
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.uoce = self.dataset.uoce
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.voce = self.dataset.voce
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.utau = self.dataset.utau
-        except AttributeError as e:
-            print(str(e))
-        try:
-            self.vtau = self.dataset.vtau
-        except AttributeError as e:
-            print(str(e))
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        return
+    
+    def set_dimension_mapping(self):
+        self.dim_mapping = None
 
     def get_contour_complex(self, var, points_x, points_y, points_z, tolerance: int = 0.2):
         smaller = self.dataset[var].sel(z=points_z, x=points_x, y=points_y, method='nearest', tolerance=tolerance)

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -14,11 +14,15 @@ class NEMO(COAsT):
         return
     
     def set_dimension_mapping(self):
-        self.dim_mapping = {'time_counter':'t_dim', 'deptht':'z_dim', 
-                            'y':'y_dim', 'x':'x_dim'}
+        #self.dim_mapping = {'time_counter':'t_dim', 'deptht':'z_dim', 
+        #                    'y':'y_dim', 'x':'x_dim'}
+        self.dim_mapping = None
         
     def set_variable_mapping(self):
-        self.var_mapping = {'time_counter':'time'}
+        #self.var_mapping = {'time_counter':'time',
+        #                    'votemper' : 'temperature',
+        #                    'temp' : 'temperature'}
+        self.var_mapping = None
 
     def get_contour_complex(self, var, points_x, points_y, points_z, tolerance: int = 0.2):
         smaller = self.dataset[var].sel(z=points_z, x=points_x, y=points_y, method='nearest', tolerance=tolerance)

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -14,7 +14,8 @@ class NEMO(COAsT):
         return
     
     def set_dimension_mapping(self):
-        self.dim_mapping = None
+        self.dim_mapping = {'time_counter':'t_dim', 'deptht':'z_dim', 
+                            'y':'y_dim', 'x':'x_dim'}
 
     def get_contour_complex(self, var, points_x, points_y, points_z, tolerance: int = 0.2):
         smaller = self.dataset[var].sel(z=points_z, x=points_x, y=points_y, method='nearest', tolerance=tolerance)

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -16,6 +16,9 @@ class NEMO(COAsT):
     def set_dimension_mapping(self):
         self.dim_mapping = {'time_counter':'t_dim', 'deptht':'z_dim', 
                             'y':'y_dim', 'x':'x_dim'}
+        
+    def set_variable_mapping(self):
+        self.var_mapping = {'time_counter':'time'}
 
     def get_contour_complex(self, var, points_x, points_y, points_z, tolerance: int = 0.2):
         smaller = self.dataset[var].sel(z=points_z, x=points_x, y=points_y, method='nearest', tolerance=tolerance)

--- a/coast/OBSERVATION.py
+++ b/coast/OBSERVATION.py
@@ -19,8 +19,8 @@ class OBSERVATION(COAsT):
         
         return: Indices corresponding to datapoints inside specified box
         """
-        lon = self.longitude.copy()
-        lat = self.latitude
+        lon = self.dataset.longitude.copy()
+        lat = self.dataset.latitude
         lon[lon>180] = lon[lon>180] - 360
         lon[lon<-180] = lon[lon<-180] + 360
         ff1 = ( lon > lonbounds[0] ).astype(int)

--- a/coast/OBSERVATION.py
+++ b/coast/OBSERVATION.py
@@ -5,9 +5,9 @@ import xarray as xa
 
 class OBSERVATION(COAsT):
 
-    def __init__(self):
-        super()
-        
+    def set_dimension_mapping(self):
+        self.dim_mapping = None
+
     def subset_indices_lonlat_box(self, lonbounds, latbounds):
         """Generates array indices for data which lies in a given lon/lat box.
 

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -226,10 +226,8 @@ alt_tmp = altimetry_nwes.subset_as_copy(time=[0,1,2,3,4])
 crps_rad = sci.crps_sonf('sossheig', sci_dom, alt_tmp, 'sla_filtered',
                     nh_radius=111, nh_type = "radius", cdf_type = "empirical",
                     time_interp = "nearest", plot=False)
-crps_box = sci.crps_sonf('sossheig', sci_dom, alt_tmp, 'sla_filtered',
-                    nh_radius=1, nh_type = "box", cdf_type = "theoretical",
-                    time_interp = "nearest", plot=False)
-if len(crps_rad)==5 and len(crps_box)==5:
+
+if len(crps_rad)==5:
     print(str(sec) + chr(subsec) + " OK - CRPS SONF done for every observation")
 else:
     print(str(sec) + chr(subsec) + " X - Problem with CRPS SONF method")

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -54,7 +54,7 @@ else:
 #                                                                             #
 subsec = subsec+1
 
-sci_dom = coast.DOMAIN(dir + fn_nemo_dom)
+sci_dom = coast.DOMAIN(dn_files + fn_nemo_dom)
 
 # Test the data has loaded
 sci_dom_attrs_ref = dict([('DOMAIN_number_total', 1),
@@ -83,7 +83,7 @@ if err_flag == False:
 #                                                                             #
 subsec = subsec+1
 
-altimetry = coast.ALTIMETRY(dir + fn_altimetry)
+altimetry = coast.ALTIMETRY(dn_files + fn_altimetry)
 
 # Test the data has loaded using attribute comparison, as for NEMO_data
 alt_attrs_ref = dict([('source', 'Jason-1 measurements'),

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -53,8 +53,7 @@ else:
 #                                                                             #
 subsec = subsec+1
 
-sci_dom = coast.DOMAIN()
-sci_dom.load(dir + fn_nemo_dom)
+sci_dom = coast.DOMAIN(dir + fn_nemo_dom)
 
 # Test the data has loaded
 sci_dom_attrs_ref = dict([('DOMAIN_number_total', 1),
@@ -83,8 +82,7 @@ if err_flag == False:
 #                                                                             #
 subsec = subsec+1
 
-altimetry = coast.ALTIMETRY()
-altimetry.load(dir + fn_altimetry)
+altimetry = coast.ALTIMETRY(dir + fn_altimetry)
 
 # Test the data has loaded using attribute comparison, as for NEMO_data
 alt_attrs_ref = dict([('source', 'Jason-1 measurements'),
@@ -97,10 +95,6 @@ if alt_attrs_ref.items() <= altimetry.dataset.attrs.items():
     print(str(sec) +chr(subsec) + " OK - Altimetry data loaded: " + fn_altimetry)
 else:
     print(str(sec) + chr(subsec) + " X - There is an issue with loading: " + fn_altimetry)
-    
-altimetry.set_command_variables()
-sci.set_command_variables()
-sci_dom.set_command_variables()
 
 #-----------------------------------------------------------------------------#
 # ( 1d ) Load data from existing dataset                                          #


### PR DESCRIPTION
@jpolton @anwiseNOCL This branch contains:

1. a new `set_dimension_names()` function inside COAsT (not the child classes). This is the dictionary iteration as discussed in the issue conversation.

2. a new `set_dimension_mapping()` function in COAsT and child classes. This is the function that sets the mapping dictionary.

The idea is that `set_dimension_names()` is called on load. It goes to the variable `self.dim_mapping` to rename dimensions. This is defined on initialisation (before load) in the `set_dimension_mapping()` method, which is kept in the child objects so it can be tailored appropriately. If it's not in a child object, the dictionary is `None` and nothing is renamed. A user can also redefine dimension names by simply putting a dictionary into `COAsT.set_dimension_names()`.

Also, some small changes to load functions:

3. There is now `load_multiple()` and `load_single()` functions inside COAsT, which do the same as before (`load_single` is as `load` was before). At the end of these functions, `set_dimension_names()` is called, so dimensions are renamed on load.

4. A new `load` function, which points to either `load_multiple()` or `load_single()` depending on whether the argument `multiple` is `True` or `False` (default False, so works as `load_single` does is not specified).

5. `load` is called as part of the initialisation, so filenames can be inputted when the object is first created. It will all still work as previously if filenames are input later on.

Do either of you know what the arguments in COAsT.__init__ are for and whether or not we can delete them? Specifically: `workers=2, threads=2, memory_limit_per_worker='2GB'` and the commented line:

```
# self.client = Client(n_workers=workers, threads_per_worker=threads, memory_limit=memory_limit_per_worker)
```

I've not updated unit_testing for this yet -- it does work though. Let me know what you think and I'll change it later.
