### PR TITLE
Landmasking added for obs_operator

### DIFF
--- a/coast/ALTIMETRY.py
+++ b/coast/ALTIMETRY.py
@@ -124,7 +124,7 @@ class ALTIMETRY(COAsT):
 ##############################################################################
     
     def obs_operator(self, model, mod_var_name:str, 
-                                time_interp = 'nearest'):
+                                time_interp = 'nearest', model_mask=None):
         '''
         For interpolating a model dataarray onto altimetry locations and times.
         
@@ -144,12 +144,24 @@ class ALTIMETRY(COAsT):
         time_interp: time interpolation method (optional, default: 'nearest')
             This can take any string scipy.interpolate would take. e.g.
             'nearest', 'linear' or 'cubic'
+        model_mask : Mask to apply to model data in geographical interpolation 
+             of model. For example, use to ignore land points. 
+             If None, no mask is applied. If 'bathy', model variable
+             (bathymetry==0) is used. Custom 2D mask arrays can be
+             supplied.
         Returns
         -------
         Adds a DataArray to self.dataset, containing interpolated values.
         '''
 
         debug(f"Interpolating {get_slug(model)} \"{mod_var_name}\" with time_interp \"{time_interp}\"")
+
+        # Determine mask
+        if model_mask=='bathy':
+            model_mask = model.dataset.bathymetry.values==0
+        
+        # Get data arrays
+        mod_var_array = model.dataset[mod_var_name]
 
         # Get data arrays
         mod_var = model.dataset[mod_var_name]

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -302,7 +302,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
         return jj1, ii1, line_length
     
     @staticmethod
-    def interpolate_in_space(model_array, new_lon, new_lat):
+    def interpolate_in_space(model_array, new_lon, new_lat, mask=None):
         '''
         Interpolates a provided xarray.DataArray in space to new longitudes
         and latitudes using a nearest neighbour method (BallTree).
@@ -317,6 +317,9 @@ class NEMO(COAsT):  # TODO Complete this docstring
         model_array (xr.DataArray): Model variable DataArray to interpolate
         new_lons (1Darray): Array of longitudes (degrees) to compare with model
         new_lats (1Darray): Array of latitudes (degrees) to compare with model
+        mask (2D array): Mask array. Where True (or 1), elements of array will
+                     not be included. For example, use to mask out land in 
+                     case it ends up as the nearest point.
         
         Returns
         -------
@@ -324,9 +327,9 @@ class NEMO(COAsT):  # TODO Complete this docstring
         '''
         debug(f"Interpolating {get_slug(model_array)} in space with nearest neighbour")
         # Get nearest indices
-        ind_x, ind_y = general_utils.nearest_xy_indices(model_array.longitude,
+        ind_x, ind_y = general_utils.nearest_indices_2D(model_array.longitude,
                                                 model_array.latitude,
-                                                new_lon, new_lat)
+                                                new_lon, new_lat, mask=mask)
         
         # Geographical interpolation (using BallTree indices)
         interpolated = model_array.isel(x_dim=ind_x, y_dim=ind_y)

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -323,6 +323,7 @@ class TIDEGAUGE():
         
         title = 'Location: ' + self.dataset.attrs['site_name']
         X = self.dataset.longitude
+        Y = self.dataset.latitude
         fig, ax =  plot_util.geo_scatter(X, Y, title=title, 
                                          xlim = [X-10, X+10],
                                          ylim = [Y-10, Y+10])

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -324,6 +324,8 @@ class TIDEGAUGE():
         title = 'Location: ' + self.dataset.attrs['site_name']
         X = self.dataset.longitude
         Y = self.dataset.latitude
+        print(X)
+        print(Y)
         fig, ax =  plot_util.geo_scatter(X, Y, title=title, 
                                          xlim = [X-10, X+10],
                                          ylim = [Y-10, Y+10])
@@ -436,7 +438,8 @@ class TIDEGAUGE():
 ###                ~        Model Comparison         ~                     ###
 ##############################################################################
     
-    def obs_operator(self, model, mod_var_name:str, time_interp = 'nearest'):
+    def obs_operator(self, model, mod_var_name:str, time_interp = 'nearest',
+                     model_mask = None):
         '''
         Interpolates a model array (specified using a model object and variable
         string) to TIDEGAUGE location and times. Takes the nearest model grid
@@ -447,11 +450,19 @@ class TIDEGAUGE():
         model : MODEL object (e.g. NEMO)
         model_var_name (str) : Name of variable (inside MODEL) to interpolate.
         time_interp (str) : type of scipy time interpolation (e.g. linear)
+        model_mask : Mask to apply to model data in geographical interpolation 
+                     of model. For example, use to ignore land points. 
+                     If None, no mask is applied. If 'bathy', model variable
+                     (bathymetry==0) is used. Custom 2D mask arrays can be
+                     supplied.
           
         Returns
         -------
         Saves interpolated array to TIDEGAUGE.dataset
         '''
+        # Determine mask
+        if model_mask=='bathy':
+            model_mask = model.dataset.bathymetry.values==0
         
         # Get data arrays
         mod_var_array = model.dataset[mod_var_name]
@@ -465,7 +476,7 @@ class TIDEGAUGE():
         obs_lat = np.array([self.dataset.latitude])
         
         interpolated = model.interpolate_in_space(mod_var_array, obs_lon, 
-                                                  obs_lat)
+                                                  obs_lat, mask=model_mask)
         
         interpolated = model.interpolate_in_time(interpolated, 
                                                  self.dataset.time)

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -323,9 +323,6 @@ class TIDEGAUGE():
         
         title = 'Location: ' + self.dataset.attrs['site_name']
         X = self.dataset.longitude
-        Y = self.dataset.latitude
-        print(X)
-        print(Y)
         fig, ax =  plot_util.geo_scatter(X, Y, title=title, 
                                          xlim = [X-10, X+10],
                                          ylim = [Y-10, Y+10])

--- a/coast/general_utils.py
+++ b/coast/general_utils.py
@@ -64,10 +64,10 @@ def reinstate_indices_by_mask(array_removed, mask, fill_value=np.nan):
     A = A.reshape(original_shape)
     return A
 
-def nearest_xy_indices(mod_lon, mod_lat, new_lon, new_lat, 
+def nearest_indices_2D(mod_lon, mod_lat, new_lon, new_lat, 
                        mask = None):
     '''
-    Obtains the x and y indices of the nearest model points to specified
+    Obtains the 2 dimensional indices of the nearest model points to specified
     lists of longitudes and latitudes. Makes use of sklearn.neighbours
     and its BallTree haversine method. 
     
@@ -85,9 +85,9 @@ def nearest_xy_indices(mod_lon, mod_lat, new_lon, new_lat,
     mod_lat (2D array): Model latitude (degrees) array (2-dimensions)
     new_lon (1D array): Array of longitudes (degrees) to compare with model
     new_lat (1D array): Array of latitudes (degrees) to compare with model
-    mask (2D array): Mask array. Where True (or 1), elements of mod_lons
-                     and mod lats will be removed prior to finding nearest
-                     neighbours. e.g. if the nearest ocean point is 
+    mask (2D array): Mask array. Where True (or 1), elements of array will
+                     not be included. For example, use to mask out land in 
+                     case it ends up as the nearest point.
         
     Returns
     -------

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -670,7 +670,7 @@ try:
     altimetry = coast.ALTIMETRY(dn_files + fn_altimetry)
     ind = altimetry.subset_indices_lonlat_box([-10,10], [45,60])
     altimetry_nwes = altimetry.isel(t_dim=ind) #nwes = northwest europe shelf
-    ind_x, ind_y = general_utils.nearest_xy_indices(sci.dataset.longitude,
+    ind_x, ind_y = general_utils.nearest_indices_2D(sci.dataset.longitude,
                                                     sci.dataset.latitude,
                                           altimetry_nwes.dataset.longitude,
                                           altimetry_nwes.dataset.latitude)
@@ -927,7 +927,8 @@ subsec = subsec+1
 
 try:
 
-    lowestoft.obs_operator(sci, 'ssh', time_interp = 'linear')
+    lowestoft.obs_operator(sci, 'ssh', time_interp = 'linear', 
+                           model_mask='bathy')
 
     #TEST: Check that the resulting interp_sossheig variable is of the same
     # length as sea_level and that it is populated.


### PR DESCRIPTION
Added some masking functionality to `obs_operator()`, `nearest_indices_2D` (formerly nearest_xy_indices) and `interpolate_in_space()`.

`nearest_indices_2D` and `interpolate_in_space` expect explicit masking arrays handed to them (or None, in which case no masking happens). `obs_operator` uses None by default and can also accept an explicit 2D masking array. It can also be handed `model_mask='bathy'`, in which case it uses NEMO.dataset.bathymetry.values==0 as the mask.

True elements of mask are ignored. Luckily BallTree apparently ignores any NaN elements of longitude/latitude input. So the masking works by setting True elements of mask in lon/lat arrays to NaN temporarily.

Updated unit_test slightly. TIDEGAUGE tests this with model_mask='bathy'. ALTIMETRY tests with no masking.