### PR TITLE
0213/doodson xo filter

### DIFF
--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -623,7 +623,9 @@ class NEMO(COAsT):  # TODO Complete this docstring
         
         !!WARNING: Will load in entire variable to memory. If dataset large,
         then subset before using this method or ensure you have enough free 
-        RAM to hold the variable (twice). '''
+        RAM to hold the variable (twice). 
+        
+        DB:: Currently not tested in unit_test.py'''
         var = self.dataset[var_str]
         new_var_str = var_str + '_dxo'
         old_dims = var.dims

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -1,5 +1,5 @@
 from .COAsT import COAsT
-from . import general_utils
+from . import general_utils, stats_util
 import xarray as xr
 import numpy as np
 # from dask import delayed, compute, visualize
@@ -616,7 +616,21 @@ class NEMO(COAsT):  # TODO Complete this docstring
             return None
         
     def apply_doodson_xo_filter(self, var_str):
+        ''' Applies Doodson XO filter to a variable. 
+    
+        Input variable is expected to be hourly.
+        Output is saved back to original dataset as {var_str}_dxo
         
+        !!WARNING: Will load in entire variable to memory. If dataset large,
+        then subset before using this method or ensure you have enough free 
+        RAM to hold the variable (twice). '''
+        var = self.dataset[var_str]
+        new_var_str = var_str + '_dxo'
+        old_dims = var.dims
+        time_index = old_dims.index('t_dim')
+        filtered = stats_util.doodson_xo_filter(var, ax=time_index)
+        if filtered is not None:
+            self.dataset[new_var_str] = (old_dims, filtered)
         return
         
         

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -615,6 +615,10 @@ class NEMO(COAsT):  # TODO Complete this docstring
             warn(f"{in_varstr} does not exist in {get_slug(self)} dataset")
             return None
         
+    def apply_doodson_xo_filter(self, var_str):
+        
+        return
+        
         
 
         

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -615,8 +615,8 @@ class NEMO(COAsT):  # TODO Complete this docstring
             warn(f"{in_varstr} does not exist in {get_slug(self)} dataset")
             return None
         
-    def apply_doodson_xo_filter(self, var_str):
-        ''' Applies Doodson XO filter to a variable. 
+    def apply_doodson_x0_filter(self, var_str):
+        ''' Applies Doodson X0 filter to a variable. 
     
         Input variable is expected to be hourly.
         Output is saved back to original dataset as {var_str}_dxo
@@ -627,10 +627,10 @@ class NEMO(COAsT):  # TODO Complete this docstring
         
         DB:: Currently not tested in unit_test.py'''
         var = self.dataset[var_str]
-        new_var_str = var_str + '_dxo'
+        new_var_str = var_str + '_dx0'
         old_dims = var.dims
         time_index = old_dims.index('t_dim')
-        filtered = stats_util.doodson_xo_filter(var, ax=time_index)
+        filtered = stats_util.doodson_x0_filter(var, ax=time_index)
         if filtered is not None:
             self.dataset[new_var_str] = (old_dims, filtered)
         return

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -685,5 +685,5 @@ class TIDEGAUGE():
         ''' Applies doodson X0 filter to a specified TIDEGAUGE variable
         Input ius expected to be hourly. Use resample_mean to average data
         to hourly frequency.'''
-        filtered = stats_util.doodson_xo_filter(self.dataset[var_str], ax=0)
+        filtered = stats_util.doodson_x0_filter(self.dataset[var_str], ax=0)
         self.dataset[var_str+'_dx0'] = ( ('time_1H'),filtered )

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -419,7 +419,6 @@ class TIDEGAUGE():
         plt.legend(var_list)
         # Title and axes
         plt.xlabel('Date')
-        plt.ylabel(var_str + ' (m)')
         plt.title('Site: ' + self.dataset.site_name)
         
         return fig, ax
@@ -682,9 +681,9 @@ class TIDEGAUGE():
         self.dataset[new_var_str] = resampled
         
 
-    def apply_doodson_xo_filter(self, var_str):
-        ''' Applies doodson XO filter to a specified TIDEGAUGE variable
+    def apply_doodson_x0_filter(self, var_str):
+        ''' Applies doodson X0 filter to a specified TIDEGAUGE variable
         Input ius expected to be hourly. Use resample_mean to average data
         to hourly frequency.'''
         filtered = stats_util.doodson_xo_filter(self.dataset[var_str], ax=0)
-        self.dataset[var_str+'_dxo'] = ( ('time_1H'),filtered )
+        self.dataset[var_str+'_dx0'] = ( ('time_1H'),filtered )

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import pandas as pd
 import glob
 import sklearn.metrics as metrics
-from . import general_utils, plot_util, crps_util
+from . import general_utils, plot_util, crps_util, stats_util
 from .logging_util import get_slug, debug, error
 
 class TIDEGAUGE():
@@ -654,3 +654,12 @@ class TIDEGAUGE():
             self.dataset['rmse'] = rmse
             self.dataset['corr'] = corr
             self.dataset['cov'] = cov
+
+##############################################################################
+###                ~            Analysis             ~                     ###
+##############################################################################
+
+    def apply_doodson_xo_filter(self, var_str):
+        
+        filtered = stats_util.doodson_xo_filter(self.dataset[var_str], ax=0)
+        self.dataset[var_str+'_dxo'] = filtered 

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -58,6 +58,10 @@ class TIDEGAUGE():
         -> time_correlation(): Correlation between two variables
         -> time_covariance(): Covariance between two variables
         -> basic_stats(): Calculates multiple of the above metrics.
+        
+        *Analysis*
+        -> resample_mean(): For resampling data in time using averaging
+        -> apply_doodson_xo_filter(): Remove tidal signal using Doodson XO
     '''  
     
 ##############################################################################
@@ -679,6 +683,8 @@ class TIDEGAUGE():
         
 
     def apply_doodson_xo_filter(self, var_str):
-        ''' Applies doodson XO filter to a specified TIDEGAUGE variable '''
+        ''' Applies doodson XO filter to a specified TIDEGAUGE variable
+        Input ius expected to be hourly. Use resample_mean to average data
+        to hourly frequency.'''
         filtered = stats_util.doodson_xo_filter(self.dataset[var_str], ax=0)
         self.dataset[var_str+'_dxo'] = ( ('time_1H'),filtered )

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -31,12 +31,16 @@ def doodson_xo_filter(elevation, ax=0):
     Parameters
     ----------
         elevation (ndarray) : Array of hourly elevation values.
-        axis (int) : Time axis of input array
+        axis (int) : Time axis of input array. This axis must have >= 39 
+        elements
        
     Returns
     -------
         Filtered array of same rank as elevation.
     ''' 
+    if elevation.shape[ax] < 39:
+        print('Doodson_XO: Ensure time axis has >=39 elements. Returning.')
+        return
     # Define DOODSON XO weights
     kern = np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 2, 0, 1, 1, 0, 2, 1, 1, 2, 
                      0,
@@ -46,6 +50,7 @@ def doodson_xo_filter(elevation, ax=0):
     # Convolve input array with weights along the specified axis.
     filtered = np.apply_along_axis(lambda m: np.convolve(m, kern, mode=1), 
                                    axis=ax, arr=elevation)
+    print(filtered.shape)
 
     # Pad out boundary areas with NaNs for given (arbitrary) axis.
     # DB: Is this the best way to do this?? Can put_along_axis be used instead

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -11,7 +11,7 @@ import numpy as np
 import xarray as xr
 from .logging_util import get_slug, debug, info, warn, error
 
-def doodson_xo_filter(elevation, ax=0):
+def doodson_x0_filter(elevation, ax=0):
     ''' 
     The Doodson X0 filter is a simple filter designed to damp out the main 
     tidal frequencies. It takes hourly values, 19 values either side of the 
@@ -60,7 +60,7 @@ def doodson_xo_filter(elevation, ax=0):
     return filtered
 
 
-def normal_distribution(self, mu: float=0, sigma: float=1, 
+def normal_distribution(mu: float=0, sigma: float=1, 
                         x: np.ndarray=None, n_pts: int=1000):
     """Generates a discrete normal distribution.
 
@@ -80,7 +80,7 @@ def normal_distribution(self, mu: float=0, sigma: float=1,
     exponent = -0.5*((x-mu)/sigma)**2
     return term1*np.exp( exponent )
 
-def cumulative_distribution(self, mu: float=0, sigma: float=1, 
+def cumulative_distribution(mu: float=0, sigma: float=1, 
                             x: np.ndarray=None, cdf_func: str='gaussian'):
     """Integrates under a discrete PDF to obtain an estimated CDF.
 
@@ -94,13 +94,13 @@ def cumulative_distribution(self, mu: float=0, sigma: float=1,
     """
     debug(f"Estimating CDF using {get_slug(x)}")
     if cdf_func=='gaussian': #If Gaussian, integrate under pdf
-        pdf = self.normal_distribution(mu=mu, sigma=sigma, x=x)
+        pdf = normal_distribution(mu=mu, sigma=sigma, x=x)
         cdf = [np.trapz(pdf[:ii],x[:ii]) for ii in range(0,len(x))]
     else: 
         raise NotImplementedError
     return np.array(cdf)
 
-def empirical_distribution(self, x, sample):
+def empirical_distribution(x, sample):
     """Estimates a CDF empirically.
 
     Keyword arguments:

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -50,7 +50,6 @@ def doodson_xo_filter(elevation, ax=0):
     # Convolve input array with weights along the specified axis.
     filtered = np.apply_along_axis(lambda m: np.convolve(m, kern, mode=1), 
                                    axis=ax, arr=elevation)
-    print(filtered.shape)
 
     # Pad out boundary areas with NaNs for given (arbitrary) axis.
     # DB: Is this the best way to do this?? Can put_along_axis be used instead

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -23,7 +23,7 @@ nemo = coast.NEMO(fn_nemo_dat, fn_nemo_dom, grid_ref='t-grid')
 # if desired, as long as it follows the data formatting for TIDEGAUGE. Here
 # we load data between two specified dates:
 date0 = datetime.datetime(2007,1,10)
-date1 = datetime.datetime(2007,1,12)
+date1 = datetime.datetime(2007,1,16)
 tidegauge = coast.TIDEGAUGE(fn_tidegauge, date_start = date0, date_end = date1)
 
 # Before comparing our observations to the model, we will interpolate a model
@@ -49,7 +49,7 @@ stats = tidegauge.basic_stats('interp_ssh', 'sea_level')
 # Now we will do a more complex comparison using the Continuous Ranked
 # Probability Score (CRPS). For this, we need to hand over the model object,
 # a model variable and an observed variable. We also give it a neighbourhood
-# radius in km (nh_radius).
+# radius in km (nh_radius). This may take a minute to run.
 crps = tidegauge.crps(nemo, model_var_name = 'ssh', obs_var_name = 'sea_level', 
                       nh_radius = 20)
 
@@ -62,7 +62,7 @@ crps = tidegauge.crps(nemo, model_var_name = 'ssh', obs_var_name = 'sea_level',
 fig, ax = tidegauge.plot_on_map()
 
 # Or to look at a time series of the sea_level variable:
-fig, ax = tidegauge.plot_timeseries('sea_level', qc_colors=True)
+fig, ax = tidegauge.plot_timeseries('sea_level')
 
 # Note that start and end dates can also be specified for plot_timeseries().
 #
@@ -70,6 +70,26 @@ fig, ax = tidegauge.plot_timeseries('sea_level', qc_colors=True)
 # functionality can be used:
 crps.plot_timeseries('crps')
 stats.plot_timeseries('absolute_error')
+
+# Lets do some analysis on just the data in TIDEGAUGE. We can attempt to remove
+# the tidal signal using a Doodson XO filter. To do this, we must first
+# resample the data to an hourly frequency. TIDEGAUGE.resample_mean() can do
+# just this using averaging.
+tidegauge.resample_mean('sea_level', '1H')
+
+# Here we have resampled the 'sea_level' object. Now, in tidegauge.dataset
+# there is a new variable sea_level_1H, along a new dimension time_1H. 1H
+# can be subsitituted for other strings (e.g. 1D = 1 day) or using timedelta
+# object. 
+#
+# Now, we can apply the doodson XO filter to the new variable:
+tidegauge.apply_doodson_xo_filter('sea_level_1H')
+
+# The new variable tidegauge.sea_level_1H_dxo contains the filtered data.
+# Now lets do another time series plot, but this time looking at the three
+# variables sea_level, sea_level_1H and sea_level_1H_dxo. We can do this
+# by providing a list of variable names:
+f,a = tidegauge.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dxo'])
 
 # Each TIDEGAUGE object only holds data for a single tidegauge. There is some
 # functionality for dealing with multiple gauges in COAsT. To load multiple

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -72,7 +72,7 @@ crps.plot_timeseries('crps')
 stats.plot_timeseries('absolute_error')
 
 # Lets do some analysis on just the data in TIDEGAUGE. We can attempt to remove
-# the tidal signal using a Doodson XO filter. To do this, we must first
+# the tidal signal using a Doodson x0 filter. To do this, we must first
 # resample the data to an hourly frequency. TIDEGAUGE.resample_mean() can do
 # just this using averaging.
 tidegauge.resample_mean('sea_level', '1H')
@@ -82,14 +82,14 @@ tidegauge.resample_mean('sea_level', '1H')
 # can be subsitituted for other strings (e.g. 1D = 1 day) or using timedelta
 # object. 
 #
-# Now, we can apply the doodson XO filter to the new variable:
-tidegauge.apply_doodson_xo_filter('sea_level_1H')
+# Now, we can apply the doodson x0 filter to the new variable:
+tidegauge.apply_doodson_x0_filter('sea_level_1H')
 
-# The new variable tidegauge.sea_level_1H_dxo contains the filtered data.
+# The new variable tidegauge.sea_level_1H_dx0 contains the filtered data.
 # Now lets do another time series plot, but this time looking at the three
-# variables sea_level, sea_level_1H and sea_level_1H_dxo. We can do this
+# variables sea_level, sea_level_1H and sea_level_1H_dx0. We can do this
 # by providing a list of variable names:
-f,a = tidegauge.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dxo'])
+f,a = tidegauge.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dx0'])
 
 # Each TIDEGAUGE object only holds data for a single tidegauge. There is some
 # functionality for dealing with multiple gauges in COAsT. To load multiple

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -962,9 +962,52 @@ try:
 
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
+    
+#-----------------------------------------------------------------------------#
+#%% ( 7e ) TIDEGAUGE Resample to hourly                                       #
+#                                                                             #
+subsec = subsec+1
+# Lets resample the tide gauge data to be hourly.
+
+try:
+    lowestoft.resample_mean('sea_level','1H')
+
+    #TEST: Check new times have right frequency
+    td0 = lowestoft.dataset.time_1H[1] - lowestoft.dataset.time_1H[0]
+    check1 = td0.values.astype('timedelta64[h]') == np.timedelta64(1,'h')
+    #TEST: Check length
+    check2 = np.ceil(lowestoft.dataset.time.shape[0]/4) == lowestoft.dataset.time_1H.shape[0]
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - TIDEGAUGE resampled")
+    else:
+        print(str(sec) + chr(subsec) + " X -  Resample TIDEGAUGE")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+    
+#-----------------------------------------------------------------------------#
+#%% ( 7f ) Apply Doodson XO filter to hourly data                             #
+#                                                                             #
+subsec = subsec+1
+# Lets resample the tide gauge data to be hourly.
+
+try:
+    lowestoft.apply_doodson_xo_filter('sea_level_1H')
+
+    #TEST: Check new times are same length as variable
+    check1 = lowestoft.dataset.time_1H.shape == lowestoft.dataset.sea_level_1H_dxo.shape
+    #TEST: Check there are number values in output 
+    check2 = False in np.isnan(lowestoft.dataset.sea_level_1H_dxo)
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - TIDEGAUGE doodson XO")
+    else:
+        print(str(sec) + chr(subsec) + " X -  TIDEGAUGE doodson XO")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
 
 #-----------------------------------------------------------------------------#
-#%% ( 7e ) TIDEGAUGE Loading multiple TIDEGAUGES                                #
+#%% ( 7g ) TIDEGAUGE Loading multiple TIDEGAUGES                                #
 #                                                                             #
 subsec = subsec+1
 # We can load multiple tide gauges into a list of TIDEGAUGE objects using the
@@ -988,7 +1031,7 @@ except:
     print(str(sec) + chr(subsec) +' FAILED.')
 
 #-----------------------------------------------------------------------------#
-#%% ( 7f ) TIDEGAUGE map plot (single)                                          #
+#%% ( 7h ) TIDEGAUGE map plot (single)                                          #
 #                                                                             #
 subsec = subsec+1
 
@@ -1003,7 +1046,7 @@ except:
 plt.close('all')
 
 #-----------------------------------------------------------------------------#
-#%% ( 7g ) TIDEGAUGE map plot (single)                                          #
+#%% ( 7i ) TIDEGAUGE map plot (single)                                          #
 #                                                                             #
 subsec = subsec+1
 
@@ -1018,14 +1061,14 @@ except:
 plt.close('all')
 
 #-----------------------------------------------------------------------------#
-#%% ( 7h ) TIDEGAUGE Time series plot                                           #
+#%% ( 7j ) TIDEGAUGE Time series plot                                           #
 #                                                                             #
 subsec = subsec+1
 
 # Take a look at the sea level time series stored within the object:
 
 try:
-    f,a = lowestoft.plot_timeseries('sea_level')
+    f,a = lowestoft.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dxo'])
     f.savefig(dn_fig + 'tidegauge_timeseries.png')
     print(str(sec) + chr(subsec) + " OK - Tide gauge time series saved")
 except:

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -992,16 +992,16 @@ subsec = subsec+1
 # Lets resample the tide gauge data to be hourly.
 
 try:
-    lowestoft.apply_doodson_xo_filter('sea_level_1H')
+    lowestoft.apply_doodson_x0_filter('sea_level_1H')
 
     #TEST: Check new times are same length as variable
-    check1 = lowestoft.dataset.time_1H.shape == lowestoft.dataset.sea_level_1H_dxo.shape
+    check1 = lowestoft.dataset.time_1H.shape == lowestoft.dataset.sea_level_1H_dx0.shape
     #TEST: Check there are number values in output 
-    check2 = False in np.isnan(lowestoft.dataset.sea_level_1H_dxo)
+    check2 = False in np.isnan(lowestoft.dataset.sea_level_1H_dx0)
     if check1 and check2:
-        print(str(sec) + chr(subsec) + " OK - TIDEGAUGE doodson XO")
+        print(str(sec) + chr(subsec) + " OK - TIDEGAUGE doodson X0")
     else:
-        print(str(sec) + chr(subsec) + " X -  TIDEGAUGE doodson XO")
+        print(str(sec) + chr(subsec) + " X -  TIDEGAUGE doodson X0")
 
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
@@ -1068,7 +1068,7 @@ subsec = subsec+1
 # Take a look at the sea level time series stored within the object:
 
 try:
-    f,a = lowestoft.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dxo'])
+    f,a = lowestoft.plot_timeseries(['sea_level', 'sea_level_1H', 'sea_level_1H_dx0'])
     f.savefig(dn_fig + 'tidegauge_timeseries.png')
     print(str(sec) + chr(subsec) + " OK - Tide gauge time series saved")
 except:

--- a/unit_testing/unit_test_contents.txt
+++ b/unit_testing/unit_test_contents.txt
@@ -52,10 +52,12 @@
     b. TIDEGAUGE obs operator
     c. Tidegauge CRPS
     d. Tiudegauge basic stats
-    e. Loading multiple tidegauges
-    f. Plotting a single tidegauge location
-    g. Plotting multiple tidegauge locations
-    h. Tidegauge time series plot
+    e. Resample TIDEGAUGE
+    f. Apply Doodson XO Filter to data
+    g. Loading multiple tidegauges
+    h. Plotting a single tidegauge location
+    i. Plotting multiple tidegauge locations
+    j. Tidegauge time series plot
 
 8. Isobath Contour Methods
     a. Extract isbath contour between two points


### PR DESCRIPTION
New Doodson_XO_Filter functionality in stats_util, TIDEGAUGE and NEMO.

The basic static method `doodson_xo_filter()` lives in `stats_util.py`. This is a modified version of @jpolton code. Hopefully, I've generalised it a little more to any sized input arrays. This method applies the Doodson weights along a numpy axis then puts Nans in for the first and last 19 elements of the time axis (to remove boundary effects). 

In `NEMO` and `TIDEGAUGE` there is the method `apply_doodson_xo_filter()`, which makes use of the static method `stats_util.doodson_xo_filter()`. This routine is specific to the object and knows which variables/dimensions to call. It assumes that the variable it is given is hourly. The new variable has the same name as the original with the added suffix _dxo. E.g. `ssh_dxo`.

For TIDEGAUGE, there is another new routine called `resample_mean`. This makes use of `xarray.resample` to resample a specified variable to a specified time frequency using averaging (hence the mean). This can be used before applying the doodson_xo_filter. It will create a new variable with the suffix _1H for hourly data (for example). In future, this method should probably be expanded to other resampling methods such as subsampling/interpolation.

Additions:
1. New methods in `TIDEGAUGE`, `NEMO` and `stats_util`.
2. Unit testing updated for `TIDEGAUGE.apply_doodson_xo_filter`
3. Unit testing NOT updated for `NEMO.apply_doodson_xo_filter` as example files dont have enough time elements. I will add as an issue to add this to testing in the future.
4. TIDEGAUGE_tutorial updated. Will also update website page.
5. `TIDEGAUGE.plot_timeseries()` has been updated. You can now supply a list of variables to plot on the same figure. This is demonstrated in the unit_testing and tutorial. However, the qc_colors option has been removed for now (maybe to be reimplemented in future as a general colour variable to the method.)
6. In TIDEGAUGE I have changed the t_dim dimension to time, so that it can be a coordinate dimension. t_dim was causing too many problems since with resample there are potentially multiple time dimensions. This might be good to apply across the board to avoid having to rename dimensions for some methods.

NOTE1: `NEMO.apply_doodson_xo_filter` will result in an entire variable being loaded to memory, which is not fantastic. I have added a note to the docstrin for this method telling the user to subset or ensure enough memory is available.

NOTE2: >=39 Time elements are needed to use `stats_util.doodson_xo_filter()`.