### PR TITLE
Read nemo harmonics

### DIFF
--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -727,13 +727,17 @@ class NEMO(COAsT):  # TODO Complete this docstring
         Modifies NEMO() dataset in place. New variables added.
         '''
         if direction == 'cart2polar':
-            self.dataset[a_var] = np.sqrt(self.dataset[x_var]**2 + \
-                                          self.dataset[y_var]**2)
-            self.dataset[g_var] = np.arctan2(self.dataset[y_var], 
-                                             self.dataset[x_var])
+            a,g = general_utils.cart2polar(self.dataset[x_var], 
+                                           self.dataset[y_var], 
+                                           degrees=degrees)
+            self.dataset[a_var] = a
+            self.dataset[g_var] = g
         elif direction == 'polar2cart':
-            self.dataset[x_var] = self.dataset[a_var]*np.
-            self.dataset[y_var] = 
+            x,y = general_utils.polar2cart(self.dataset[a_var], 
+                                           self.dataset[g_var],
+                                           degrees=degrees)
+            self.dataset[x_var] = x
+            self.dataset[y_var] = y
         else:
             print('Unknown direction setting. Choose cart2polar or polar2cart')
         

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -676,6 +676,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
         indices = np.array(indices).T.squeeze()
         
         # Index the possible names to match file names
+        print(indices)
         names_x = names_x[indices]
         names_y = names_y[indices]
         constituents = constituents[indices]

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -70,7 +70,8 @@ class NEMO(COAsT):  # TODO Complete this docstring
     def set_dimension_mapping(self):  # TODO Add a docstring
         self.dim_mapping = {'time_counter':'t_dim', 'deptht':'z_dim',
                             'depthu':'z_dim', 'depthv':'z_dim',
-                            'y':'y_dim', 'x':'x_dim'}
+                            'y':'y_dim', 'x':'x_dim',
+                            'x_grid_T':'x_dim', 'y_grid_T':'y_dim'}
         debug(f"{get_slug(self)} dim_mapping set to {self.dim_mapping}")
         self.dim_mapping_domain = {'t':'t_dim0', 'x':'x_dim', 'y':'y_dim',
                                    'z':'z_dim'}
@@ -634,8 +635,109 @@ class NEMO(COAsT):  # TODO Complete this docstring
         if filtered is not None:
             self.dataset[new_var_str] = (old_dims, filtered)
         return
+    
+    def harmonics_combine(self, constituents, components = ['x','y']):
+        '''
+        Contains a new NEMO object containing combined harmonic information
+        from the original object. 
         
+        NEMO saves harmonics to individual variables such as M2x, M2y... etc. 
+        This routine will combine these variables (depending on constituents)
+        into a single data array. This new array will have the new dimension
+        'constituent' and a new data coordinate 'constituent_name'.
         
+        Parameters
+        ----------
+        constituents : List of strings containing constituent names to combine.
+                       The case of these strings should match that used in 
+                       NEMO output. If a constituent is not found, no problem,
+                       it just won't be in the combined dataset.
+        components   : List of strings containing harmonic components to look
+                       for. By default, this looks for the complex components
+                       'x' and 'y'. E.g. if constituents = ['M2'] and
+                       components is left as default, then the routine looks
+                       for ['M2x', and 'M2y']. 
+
+        Returns
+        -------
+        NEMO() object, containing combined harmonic variables in a new dataset.
+        '''
+        
+        # Select only the specified constituents. NEMO model harmonics names are
+        # things like "M2x" and "M2y". Ignore current harmonics. Start by constructing
+        # the possible variable names
+        names_x = np.array([cc + components[0] for cc in constituents])
+        names_y = np.array([cc + components[1] for cc in constituents])
+        constituents = np.array(constituents, dtype='str')
+        
+        # Compare against names in file
+        var_keys = np.array(list(self.dataset.keys()))
+        indices = [np.where( names_x == ss) for ss in names_x if ss in var_keys]
+        indices = np.array(indices).T.squeeze()
+        
+        # Index the possible names to match file names
+        names_x = names_x[indices]
+        names_y = names_y[indices]
+        constituents = constituents[indices]
+        
+        # Concatenate x and y variables into one array
+        x_arrays = [self.dataset[ss] for ss in names_x]
+        harmonic_x = 'harmonic_'+components[0]
+        x_data = xr.concat(x_arrays, dim = 'constituent').rename(harmonic_x)
+        y_arrays = [self.dataset[ss] for ss in names_y]
+        harmonic_y = 'harmonic_'+components[1]
+        y_data = xr.concat(y_arrays, dim = 'constituent').rename(harmonic_y)
+        
+        nemo_harmonics = NEMO()
+        nemo_harmonics.dataset = xr.merge([x_data, y_data])
+        nemo_harmonics.dataset['constituent'] = constituents
+        
+        return nemo_harmonics
+        
+    def harmonics_convert(self, direction='cart2polar',
+                          x_var='harmonic_x', y_var='harmonic_y',
+                          a_var='harmonic_a', g_var='harmonic_g',
+                          degrees=True):
+        '''
+        Converts NEMO harmonics from cartesian to polar or vice versa.
+        Make sure this NEMO object contains combined harmonic variables
+        obtained using harmonics_combine().
+        
+        *Note:
+        
+        Parameters
+        ----------
+        direction (str) : Choose 'cart2polar' or 'polar2cart'. If 'cart2polar'
+                          Then will look for variables x_var and y_var. If 
+                          polar2cart, will look for a_var (amplitude) and 
+                          g_var (phase).
+        x_var (str)     : Harmonic x variable name in dataset (or output)
+                          default = 'harmonic_x'.
+        y_var (str)     : Harmonic y variable name in dataset (or output)
+                          default = 'harmonic_y'.
+        a_var (str)     : Harmonic amplitude variable name in dataset (or output)
+                          default = 'harmonic_a'.
+        g_var (str)     : Harmonic phase variable name in dataset (or output)
+                          default = 'harmonic_g'.
+        degrees (bool)  : Whether input/output phase are/will be in degrees.
+                          Default is True.
+
+        Returns
+        -------
+        Modifies NEMO() dataset in place. New variables added.
+        '''
+        if direction == 'cart2polar':
+            self.dataset[a_var] = np.sqrt(self.dataset[x_var]**2 + \
+                                          self.dataset[y_var]**2)
+            self.dataset[g_var] = np.arctan2(self.dataset[y_var], 
+                                             self.dataset[x_var])
+        elif direction == 'polar2cart':
+            self.dataset[x_var] = self.dataset[a_var]*np.
+            self.dataset[y_var] = 
+        else:
+            print('Unknown direction setting. Choose cart2polar or polar2cart')
+        
+        return
 
         
         

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -94,6 +94,8 @@ fn_altimetry = 'COAsT_example_altimetry_data.nc'
 fn_tidegauge = dn_files + 'tide_gauges/lowestoft-p024-uk-bodc'
 fn_tidegauge2 = dn_files + 'tide_gauges/LIV2010.txt'
 fn_EN4 = dn_files + 'EN4_example.nc'
+fn_nemo_harmonics = "coast_nemo_harmonics.nc"
+fn_nemo_harmonics_dom    = "coast_nemo_harmonics_dom.nc"
 
 sec = 1
 subsec = 96 # Code for '`' (1 below 'a')
@@ -273,6 +275,56 @@ except:
           .format(dn_files, file_names_amm7) )
 
 subsec = subsec+1
+
+#-----------------------------------------------------------------------------#
+# ( 1i ) Load and combine harmonics                                           #
+#                                                                             #
+
+subsec = subsec+1
+# Load in a NEMO data file containing harmonics and combine them into a new
+# NEMO obejct and dataset.
+
+try:
+    harmonics = coast.NEMO(dn_files + fn_nemo_harmonics, 
+                           dn_files + fn_nemo_harmonics_dom)
+    constituents = ['K1','M2','S2','K2']
+    harmonics_combined = harmonics.harmonics_combine(constituents)
+
+    #TEST: Check values in arrays and constituents
+    check1 = list(harmonics_combined.dataset.constituent.values) == constituents
+    check2 = harmonics_combined.dataset.harmonic_x[1].values == harmonics.dataset.M2x.values
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - Harmonics loaded and combined")
+    else:
+        print(str(sec) + chr(subsec) + " X - Problem combining harmonics")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+    
+#-----------------------------------------------------------------------------#
+# ( 1j ) Convert harmonics to a/g and back                                    #
+#                                                                             #
+
+subsec = subsec+1
+# Convert the harmonics loaded in 1i to amplitude and phase
+
+try:
+    harmonics_combined.harmonics_convert(direction='cart2polar')
+    harmonics_combined.harmonics_convert(direction='polar2cart',
+                                         x_var='x_test', y_var='y_test')
+
+    #TEST: Check variables and differences
+    check1 = 'x_test' in harmonics_combined.dataset.keys()
+    diff = harmonics_combined.dataset.harmonic_x[0].values - harmonics_combined.dataset.x_test[0].values
+    check2 = np.max(np.abs(diff)) < 1e-6
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - Harmonics converted")
+    else:
+        print(str(sec) + chr(subsec) + " X - Problem converting harmonics")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+
 '''
 #################################################
 ## ( 2 ) Test general utility methods in COAsT ##

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -277,7 +277,7 @@ except:
 subsec = subsec+1
 
 #-----------------------------------------------------------------------------#
-# ( 1i ) Load and combine harmonics                                           #
+# ( 1j ) Load and combine harmonics                                           #
 #                                                                             #
 
 subsec = subsec+1
@@ -293,7 +293,7 @@ try:
     #TEST: Check values in arrays and constituents
     check1 = list(harmonics_combined.dataset.constituent.values) == constituents
     check2 = harmonics_combined.dataset.harmonic_x[1].values == harmonics.dataset.M2x.values
-    if check1 and check2:
+    if check1 and check2.all():
         print(str(sec) + chr(subsec) + " OK - Harmonics loaded and combined")
     else:
         print(str(sec) + chr(subsec) + " X - Problem combining harmonics")
@@ -302,7 +302,7 @@ except:
     print(str(sec) + chr(subsec) +' FAILED.')
     
 #-----------------------------------------------------------------------------#
-# ( 1j ) Convert harmonics to a/g and back                                    #
+# ( 1k ) Convert harmonics to a/g and back                                    #
 #                                                                             #
 
 subsec = subsec+1


### PR DESCRIPTION
Added two routines for managing and converting NEMO harmonics:

NEMO.harmonics.combine(): Method for combining harmonics variables into one single dataarray with a 'constituent' dimension. The idea is you would read the file in using the normal load methods, then call this method to create a new NEMO object containing the combined harmonics. You can specify which harmonics to combine. There is an additional varaible which can be changed if you are doing this for currents, but by default it looks for 'x' and 'y'.

NEMO.harmonics.convert(): Method for converting harmonics from polar/complex to cartesian, and vice versa. This is intended to be used after the combine method. There are default variable names it will look for/save or you can change them if necessary.

Also added a few more keys to the dimension mapping for NEMO. 

Updated unit testing. Needs another new example file & domain containing harmonics, cut out from the global tide model. This is in the same place as the EN4 example data, but will have to be put into the main download at some point. Link:

https://nercacuk-my.sharepoint.com/:f:/g/personal/dbyrne_noc_ac_uk/Ek3SyAFVR_ZBpNscAYuoNtAB1Xq26iVut_y_7-toezbQjA?e=G3LJ70
