### PR TITLE
Maker maker

### DIFF
--- a/coast/MASK_MAKER.py
+++ b/coast/MASK_MAKER.py
@@ -1,0 +1,141 @@
+from .COAsT import COAsT
+import xarray as xr
+import numpy as np
+import skimage.draw as draw
+from . import general_utils
+
+class MASK_MAKER(): 
+
+    def __init__(self):
+        
+        return
+    
+    @staticmethod
+    def fill_polygon_by_index(array_to_fill, vertices_r, vertices_c, 
+                              fill_value = 1, additive = False):
+        """
+        Draws and fills a polygon onto an existing numpy array based on array
+        indices. To create a new mask, give np.zeros(shape) as input. 
+        Polygon vertices are drawn in the order given.
+        
+        Parameters
+        ----------
+        array_to_fill (2D array): Array onto which to fill polygon
+        vertices_r (1D array): Row indices for polygon vertices
+        vertices_c (1D_array): Column indices for polygon vertices
+        fill_value (float, bool or int): Fill value for polygon (Default: 1)
+        additive (bool): If true, add fill value to existing array. Otherwise
+                         indices will be overwritten. (Default: False)
+
+        Returns
+        -------
+        Filled 2D array
+        """
+        array_to_fill = np.array(array_to_fill)
+        polygon_ind = draw.polygon(vertices_r, vertices_c, 
+                                       array_to_fill.shape)
+        if additive:
+            array_to_fill[polygon_ind[0], polygon_ind[1]] += fill_value
+        else:
+            array_to_fill[polygon_ind[0], polygon_ind[1]] = fill_value
+        return array_to_fill
+    
+    @staticmethod
+    def fill_polygon_by_lonlat(array_to_fill, longitude, latitude, 
+                               vertices_lon, vertices_lat, fill_value = 1,
+                               additive = False):
+        """
+        Draws and fills a polygon onto an existing numpy array based on 
+        vertices defined by longitude and latitude locations. This does NOT
+        draw a polygon on a sphere, but instead based on straight lines 
+        between points. This is OK for small regional areas, but not advisable
+        for large and global regions.
+        Polygon vertices are drawn in the order given.
+        
+        Parameters
+        ----------
+        array_to_fill (2D array): Array onto which to fill polygon
+        vertices_r (1D array): Row indices for polygon vertices
+        vertices_c (1D_array): Column indices for polygon vertices
+        fill_value (float, bool or int): Fill value for polygon (Default: 1)
+        additive (bool): If true, add fill value to existing array. Otherwise
+                         indices will be overwritten. (Default: False)
+
+        Returns
+        -------
+        Filled 2D array
+        """
+        array_to_fill = np.array(array_to_fill)
+        ind2D = general_utils.nearest_indices_2D(longitude, latitude, 
+                                                 vertices_lon, vertices_lat)
+        
+        polygon_ind = draw.polygon(ind2D[1], ind2D[0], array_to_fill.shape)
+        if additive:
+            array_to_fill[polygon_ind[0], polygon_ind[1]] += fill_value
+        else:
+            array_to_fill[polygon_ind[0], polygon_ind[1]] = fill_value
+        return array_to_fill
+    
+    @classmethod
+    def region_def_nws_north_sea(cls, longitude, latitude, bath):
+        '''
+        Regional definition for the North Sea (Northwest European Shelf)
+        Longitude, latitude and bath should be 2D arrays corresponding to model
+        coordinates and bathymetry. Bath should be positive with depth.
+        '''
+        vertices_lon = [-5.34, -0.7, 7.5, 7.5, 9, 9, 
+                        6.3, 6.3, 5, 5, 4.126, 4.126, -1.071]
+        vertices_lat = [56.93, 54.09, 54.09, 55.5, 55.5, 57.859, 57.859, 
+                        58.121, 58.121, 58.59, 58.59, 60.5, 60.5]
+        mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
+                                      longitude, latitude,
+                                      vertices_lon, vertices_lat)
+        mask = mask * (bath<200)
+        return mask
+
+    @classmethod
+    def region_def_nws_outer_shelf(cls, longitude, latitude, bath):
+        '''
+        Regional definition for the Outher Shelf (Northwest European Shelf)
+        Longitude, latitude and bath should be 2D arrays corresponding to model
+        coordinates and bathymetry. Bath should be positive with depth.
+        '''
+        vertices_lon = [-3.57, -10.4, -1, 3.171, 3.171, -3.76, -3.76, -11.47, 
+                        -11.47, -22, -22]
+        vertices_lat = [47.95, 52.71, 60.5, 60.45, 63.3, 63.3, 60.45, 60.45, 
+                        55.28, 55.3, 47.95]
+        mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
+                                      longitude, latitude,
+                                      vertices_lon, vertices_lat)
+        mask = mask * (bath<200)
+        return mask
+
+    @classmethod
+    def region_def_nws_norwegian_trench(cls, longitude, latitude, bath):
+        '''
+        Regional definition for the Norwegian Trench (Northwest European Shelf)
+        Longitude, latitude and bath should be 2D arrays corresponding to model
+        coordinates and bathymetry. Bath should be positive with depth.
+        '''
+        vertices_lon = [10.65, 1.12, 1.12, 10.65]
+        vertices_lat = [61.83, 61.83, 48, 48]
+        mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
+                                      longitude, latitude,
+                                      vertices_lon, vertices_lat)
+        mask = mask * (bath>200)
+        return mask
+
+    @classmethod    
+    def region_def_nws_english_channel(cls, longitude, latitude, bath):
+        '''
+        Regional definition for the English Channel (Northwest European Shelf)
+        Longitude, latitude and bath should be 2D arrays corresponding to model
+        coordinates and bathymetry. Bath should be positive with depth.
+        '''
+        vertices_lon = [7.57, 7.57, -.67, -2, -2, -4.8, -4.8, -3.5, 12, 14]
+        vertices_lat = [55, 54, 54, 55, 50.5, 50.5, 48.8, 48, 48, 55]
+        mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
+                                      longitude, latitude,
+                                      vertices_lon, vertices_lat)
+        mask = mask * (bath<200)
+        return mask

--- a/coast/MASK_MAKER.py
+++ b/coast/MASK_MAKER.py
@@ -83,14 +83,15 @@ class MASK_MAKER():
         Longitude, latitude and bath should be 2D arrays corresponding to model
         coordinates and bathymetry. Bath should be positive with depth.
         '''
-        vertices_lon = [-5.34, -0.7, 7.5, 7.5, 9, 9, 
-                        6.3, 6.3, 5, 5, 4.126, 4.126, -1.071]
-        vertices_lat = [56.93, 54.09, 54.09, 55.5, 55.5, 57.859, 57.859, 
-                        58.121, 58.121, 58.59, 58.59, 60.5, 60.5]
+        vertices_lon = [-5.34,  -0.7,   7.5,    7.5,   9,     9, 
+                        6.3,    6.3,    5,      5,     4.126, 4.126, -1.071]
+        vertices_lat = [56.93,  54.09,  54.09,  56,    56,    57.859, 
+                        57.859, 58.121, 58.121, 58.59, 58.59, 60.5,  60.5]
+
         mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
                                       longitude, latitude,
                                       vertices_lon, vertices_lat)
-        mask = mask * (bath<200)
+        mask = mask * (bath<200) * (bath>0) * (~xr.ufuncs.isnan(bath))
         return mask
 
     @classmethod
@@ -100,14 +101,14 @@ class MASK_MAKER():
         Longitude, latitude and bath should be 2D arrays corresponding to model
         coordinates and bathymetry. Bath should be positive with depth.
         '''
-        vertices_lon = [-3.57, -10.4, -1, 3.171, 3.171, -3.76, -3.76, -11.47, 
-                        -11.47, -22, -22]
-        vertices_lat = [47.95, 52.71, 60.5, 60.45, 63.3, 63.3, 60.45, 60.45, 
-                        55.28, 55.3, 47.95]
+        vertices_lon = [-4,    -9.5,  -1,   3.171, 3.171, -3.76, -3.76, -12, 
+                        -12,   -12,   -4]
+        vertices_lat = [50.5,  52.71, 60.5, 60.45, 63.3,  63.3,  60.45, 60.45, 
+                        55.28, 48,    48]
         mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
                                       longitude, latitude,
                                       vertices_lon, vertices_lat)
-        mask = mask * (bath<200)
+        mask = mask * (bath<200) * (bath>0) * (~xr.ufuncs.isnan(bath))
         return mask
 
     @classmethod
@@ -117,12 +118,12 @@ class MASK_MAKER():
         Longitude, latitude and bath should be 2D arrays corresponding to model
         coordinates and bathymetry. Bath should be positive with depth.
         '''
-        vertices_lon = [10.65, 1.12, 1.12, 10.65]
-        vertices_lat = [61.83, 61.83, 48, 48]
+        vertices_lon = [10.65, 1.12,  1.12, 10.65]
+        vertices_lat = [61.83, 61.83, 48,   48]
         mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
                                       longitude, latitude,
                                       vertices_lon, vertices_lat)
-        mask = mask * (bath>200)
+        mask = mask * (bath>200) * (bath>0) * (~xr.ufuncs.isnan(bath))
         return mask
 
     @classmethod    
@@ -132,10 +133,10 @@ class MASK_MAKER():
         Longitude, latitude and bath should be 2D arrays corresponding to model
         coordinates and bathymetry. Bath should be positive with depth.
         '''
-        vertices_lon = [7.57, 7.57, -.67, -2, -2, -4.8, -4.8, -3.5, 12, 14]
-        vertices_lat = [55, 54, 54, 55, 50.5, 50.5, 48.8, 48, 48, 55]
+        vertices_lon = [7.57, 7.57,  -0.67,  -2,   -3.99, -3.99, -3.5, 12, 14]
+        vertices_lat = [56,   54.08, 54.08,  50.7, 50.7,  48.8,  48,   48, 56]
         mask = cls.fill_polygon_by_lonlat(np.zeros(longitude.shape),
                                       longitude, latitude,
                                       vertices_lon, vertices_lat)
-        mask = mask * (bath<200)
+        mask = mask * (bath<200) * (bath>0) * (~xr.ufuncs.isnan(bath))
         return mask

--- a/coast/__init__.py
+++ b/coast/__init__.py
@@ -8,6 +8,7 @@ from .CDF import CDF
 from .INTERNALTIDE import INTERNALTIDE
 from .TIDEGAUGE import TIDEGAUGE
 from .PROFILE import PROFILE
+from .MASK_MAKER import MASK_MAKER
 from . import logging_util
 from . import general_utils
 from . import plot_util

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -1571,6 +1571,79 @@ try:
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
 
+#%%
+'''
+#################################################
+## ( 12 ) MASK_MAKER                           ##
+#################################################
+'''
+
+sec = sec+1
+subsec = 96
+
+# Preparation: Create two arrays to put mask onto, one of zeros and one of ones
+# This allows us to test the additive feature.
+sci = coast.NEMO(dn_files + fn_nemo_dat, dn_files + fn_nemo_dom, grid_ref = 't-grid')
+mask00 = np.zeros((sci.dataset.dims['y_dim'], sci.dataset.dims['x_dim']))
+mask01 = np.ones((sci.dataset.dims['y_dim'], sci.dataset.dims['x_dim']))
+
+#-----------------------------------------------------------------------------#
+# ( 12a ) Create mask by indices                                              #
+#                                                                             #
+
+subsec = subsec+1
+# Plot ts diagram
+
+try:
+    mm = coast.MASK_MAKER()
+    # Draw and fill a square
+    vertices_r = [50, 150, 150, 50]
+    vertices_c = [50, 50, 150, 150]
+    filled0 = mm.fill_polygon_by_index(mask00, vertices_r, vertices_c)
+    filled1 = mm.fill_polygon_by_index(mask01, vertices_r, vertices_c, additive=True)
+
+    #TEST: Check some data
+    check1 = filled0[49,49] == 0 and filled0[51,51] == 1
+    check2 = filled1[49,49] == 1 and filled1[51,51] == 2
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - MASKS created by index")
+    else:
+        print(str(sec) + chr(subsec) + " X - Problem mask creation by index")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+    
+#-----------------------------------------------------------------------------#
+# ( 12b ) Create mask by lonlat                                               #
+#                                                                             #
+
+subsec = subsec+1
+# Plot ts diagram
+
+try:
+    mm = coast.MASK_MAKER()
+    # Draw and fill a square
+    vertices_lon = [-5, -5, 5, 5]
+    vertices_lat = [40, 60, 60, 40]
+    filled0 = mm.fill_polygon_by_lonlat(mask00, sci.dataset.longitude, 
+                                        sci.dataset.latitude, vertices_lon, 
+                                        vertices_lat)
+    filled1 = mm.fill_polygon_by_lonlat(mask01, sci.dataset.longitude, 
+                                        sci.dataset.latitude, vertices_lon, 
+                                        vertices_lat, additive=True)
+
+    #TEST: Check some data
+    check1 = filled0[50,50] == 0 and filled0[50,150] == 1
+    check2 = filled1[50,50] == 1 and filled1[50,150] == 2
+    if check1 and check2:
+        print(str(sec) + chr(subsec) + " OK - MASKS created by index")
+    else:
+        print(str(sec) + chr(subsec) + " X - Problem mask creation by index")
+
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+    
+
 #%% Close log file
 #################################################
 log_file.close()

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -1636,9 +1636,9 @@ try:
     check1 = filled0[50,50] == 0 and filled0[50,150] == 1
     check2 = filled1[50,50] == 1 and filled1[50,150] == 2
     if check1 and check2:
-        print(str(sec) + chr(subsec) + " OK - MASKS created by index")
+        print(str(sec) + chr(subsec) + " OK - MASKS created by lonlat")
     else:
-        print(str(sec) + chr(subsec) + " X - Problem mask creation by index")
+        print(str(sec) + chr(subsec) + " X - Problem mask creation by lonlat")
 
 except:
     print(str(sec) + chr(subsec) +' FAILED.')


### PR DESCRIPTION
Contains two routines for helping to draw masks using vertices:

fill_polygon_by_index() : Pass in an array and two sets of row/column indices, and it will use skimage to fill a polygon onto the input array. If additive = True, then values will be added at mask locations. Else, they will be replaced.

fill_polygon_by_lonlat(): Same as above but does a nearest neighbour interpolation first to identify indices to use for drawing.

Then I have added some regional definitions:

region_def_nws_north_sea()
region_def_nws_outer_shelf()
region_def_nws_norwegian_trench()
region_def_nws_english_channel()

You can pass these routines longitude/latitude arrays along with bathymetry and they will draw the corresponding regions. They are also a useful way of storing the vertices. The vertices are based on those defined by @anwiseNOCL, which were based on those defined by JennyG. 

There's some differences between the methods. This method takes a lot longer because of the nearest neighbour interpolation. For the AMM15 coordinates, it's not very quick (still seconds though). But this shouldn't matter seeing as you only really need to define a mask once.

Another difference is that defining using lon/lat booleans would draw something like arc distance type lines, whereas this will draw straight lines onto the array (since when drawing, it knows nothing about the spherical geography).

@jpolton @anwiseNOCL Unit testing updated and ready for review