### PR TITLE
find_maxima() w/ method=cubic spline

### DIFF
--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -917,7 +917,7 @@ class TIDEGAUGE():
             fig, ax =  plot_util.geo_scatter(X, Y, title=title)
         else:
             fig, ax =  plot_util.geo_scatter(X, Y, title=title, c = C)
-            
+
         ax.set_xlim((min(X)-10, max(X)+10))
         ax.set_ylim((min(Y)-10, max(Y)+10))
         return fig, ax
@@ -1245,7 +1245,6 @@ class TIDEGAUGE():
                                 **kwargs):
         '''
         Finds high and low water for a given variable.
-        Intended for use on 2-pt oscillating tide table data.
         Returns in a new TIDEGAUGE object with similar data format to
         a TIDETABLE.
 
@@ -1253,8 +1252,11 @@ class TIDEGAUGE():
         'comp' :: Find maxima by comparison with neighbouring values.
                   Uses scipy.signal.find_peaks. **kwargs passed to this routine
                   will be passed to scipy.signal.find_peaks.
-        DB NOTE: Currently only the 'comp' method is implemented. Future
-                 methods include linear interpolation and cublic splines.
+        'cubic':: Find the maxima using the roots of cubic spline.
+                  Uses scipy.interpolate.InterpolatedUnivariateSpline
+                  and scipy.signal.argrelmax. **kwargs are not activated.
+        NOTE: Currently only the 'comp' and 'cubic' methods implemented. Future
+                  methods include linear interpolation or refinements.
         '''
 
         x = self.dataset.time

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -1245,6 +1245,7 @@ class TIDEGAUGE():
                                 **kwargs):
         '''
         Finds high and low water for a given variable.
+        Intended for use on 2-pt oscillating tide table data.
         Returns in a new TIDEGAUGE object with similar data format to
         a TIDETABLE.
 

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -12,61 +12,135 @@ import xarray as xr
 from .logging_util import get_slug, debug, info, warn, error
 import scipy
 
+def quadratic_spline_roots(spl):
+    """
+    A custom function for the roots of a quadratic spline. Cleverness found at
+    https://stackoverflow.com/questions/50371298/find-maximum-minimum-of-a-1d-interpolated-function
+    Used in find_maxima().
+    """
+    roots = []
+    knots = spl.get_knots()
+    for a, b in zip(knots[:-1], knots[1:]):
+        u, v, w = spl(a), spl((a+b)/2), spl(b)
+        t = np.roots([u+w-2*v, w-u, 2*v])
+        t = t[np.isreal(t) & (np.abs(t) <= 1)]
+        roots.extend(t*(b-a)/2 + (b+a)/2)
+    return np.array(roots)
+
 def find_maxima(x, y, method='comp', **kwargs):
     '''
     Finds maxima of a time series y. Returns maximum values of y (e.g heights)
-    and corresponding values of x (e.g. times). 
+    and corresponding values of x (e.g. times).
     **kwargs are dependent on method.
-    
+
         Methods:
         'comp' :: Find maxima by comparison with neighbouring values.
                   Uses scipy.signal.find_peaks. **kwargs passed to this routine
                   will be passed to scipy.signal.find_peaks.
-        DB NOTE: Currently only the 'comp' method is implemented. Future
-                 methods include linear interpolation and cublic splines.
+        'cubic' :: Find the maxima and minima by fitting a cubic spline and
+                    finding the roots of its derivative.
+        DB NOTE: Currently only the 'comp' and 'cubic' method are implemented.
+                Future methods include linear interpolation.
+
+        JP NOTE: Cubic method:
+            i) has ineligent fix for NaNs,
+            ii) first converts x,y into np.floats64 for calc
+            iii) probably assumes x,y are xr.DataArrays
     '''
     if method == 'comp':
         peaks, props = scipy.signal.find_peaks(y, **kwargs)
         return x[peaks], y[peaks]
 
+    if method == 'cubic':
+        """
+        Cleverness found at
+        https://stackoverflow.com/questions/50371298/find-maximum-minimum-of-a-1d-interpolated-function
+
+        Find the extrema on a cubic spline fitted to 1d array. E.g:
+        # Some data
+        x_axis = np.array([ 2.14414414,  2.15270826,  2.16127238,  2.1698365 ,  2.17840062, 2.18696474,  2.19552886,  2.20409298,  2.2126571 ,  2.22122122])
+        y_axis = np.array([ 0.67958442,  0.89628424,  0.78904004,  3.93404167,  6.46422317, 6.40459954,  3.80216674,  0.69641825,  0.89675386,  0.64274198])
+        # Fit cubic spline
+        f = interp1d(x_axis, y_axis, kind = 'cubic')
+        x_new = np.linspace(x_axis[0], x_axis[-1],100)
+        fig = plt.subplots()
+        plt.plot(x_new, f(x_new)) # The fitted spline
+        plt.plot(cr_pts, cr_vals, '+') # The extrema
+
+        """
+        # Remove NaNs
+        I = np.isnan(y)
+        if sum(I) > 0:
+            print('find_maxima(): There were NaNs in timeseries')
+            x = x[np.logical_not(I)]
+            y = y[np.logical_not(I)]
+
+        # Sort over time. Monotonic increasing
+        y = y.sortby(x)
+        x = x.sortby(x)
+
+        # Convert x to float64 (assuming y is/similar to np.float64)
+        if type(x.values[0]) == np.datetime64:
+            x_float = x.values.astype('d')
+            y_float = y.values.astype('d')
+            flag_dt64 = True
+        else:
+            x_float = x.values.astype('d')
+            y_float = y.values.astype('d')
+            flag_dt64 = False
+
+        if type(y.values[0]) != np.float64:
+            print('find_maxima(): type(y)=',type(y))
+            print('I was expecting a np.float64')
+
+        # Do the interpolation
+        f = scipy.interpolate.InterpolatedUnivariateSpline(x_float, y, k=3)
+        cr_pts = quadratic_spline_roots(f.derivative())
+        cr_vals = f(cr_pts)
+
+        if flag_dt64:
+            return cr_pts.astype('datetime64'), cr_vals
+        else:
+            return cr_pts, cr_vals
+
 def doodson_x0_filter(elevation, ax=0):
-    ''' 
-    The Doodson X0 filter is a simple filter designed to damp out the main 
-    tidal frequencies. It takes hourly values, 19 values either side of the 
+    '''
+    The Doodson X0 filter is a simple filter designed to damp out the main
+    tidal frequencies. It takes hourly values, 19 values either side of the
     central one and applies a weighted average using:
               (1010010110201102112 0 2112011020110100101)/30.
     ( http://www.ntslf.org/files/acclaimdata/gloup/doodson_X0.html )
-    
+
     In "Data Analaysis and Methods in Oceanography":
-    
+
     "The cosine-Lanczos filter, the transform filter, and the
     Butterworth filter are often preferred to the Godin filter,
     to earlier Doodson filter, because of their superior ability
     to remove tidal period variability from oceanic signals."
-    
+
     This routine can be used for any dimension input array.
-    
+
     Parameters
     ----------
         elevation (ndarray) : Array of hourly elevation values.
-        axis (int) : Time axis of input array. This axis must have >= 39 
+        axis (int) : Time axis of input array. This axis must have >= 39
         elements
-       
+
     Returns
     -------
         Filtered array of same rank as elevation.
-    ''' 
+    '''
     if elevation.shape[ax] < 39:
         print('Doodson_XO: Ensure time axis has >=39 elements. Returning.')
         return
     # Define DOODSON XO weights
-    kern = np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 2, 0, 1, 1, 0, 2, 1, 1, 2, 
+    kern = np.array([1, 0, 1, 0, 0, 1, 0, 1, 1, 0, 2, 0, 1, 1, 0, 2, 1, 1, 2,
                      0,
                      2, 1, 1, 2, 0, 1, 1, 0, 2, 0, 1, 1, 0, 1, 0, 0, 1, 0, 1])
     kern = kern/30
 
     # Convolve input array with weights along the specified axis.
-    filtered = np.apply_along_axis(lambda m: np.convolve(m, kern, mode=1), 
+    filtered = np.apply_along_axis(lambda m: np.convolve(m, kern, mode=1),
                                    axis=ax, arr=elevation)
 
     # Pad out boundary areas with NaNs for given (arbitrary) axis.
@@ -78,7 +152,7 @@ def doodson_x0_filter(elevation, ax=0):
     return filtered
 
 
-def normal_distribution(mu: float=0, sigma: float=1, 
+def normal_distribution(mu: float=0, sigma: float=1,
                         x: np.ndarray=None, n_pts: int=1000):
     """Generates a discrete normal distribution.
 
@@ -86,7 +160,7 @@ def normal_distribution(mu: float=0, sigma: float=1,
     x     -- Arbitrary array of x-values
     mu    -- Distribution mean
     sigma -- Distribution standard deviation
-    
+
     return: Array of len(x) containing the normal values calculated from
             the elements of x.
     """
@@ -98,7 +172,7 @@ def normal_distribution(mu: float=0, sigma: float=1,
     exponent = -0.5*((x-mu)/sigma)**2
     return term1*np.exp( exponent )
 
-def cumulative_distribution(mu: float=0, sigma: float=1, 
+def cumulative_distribution(mu: float=0, sigma: float=1,
                             x: np.ndarray=None, cdf_func: str='gaussian'):
     """Integrates under a discrete PDF to obtain an estimated CDF.
 
@@ -106,15 +180,15 @@ def cumulative_distribution(mu: float=0, sigma: float=1,
     x   -- Arbitrary array of x-values
     pdf -- PDF corresponding to values in x. E.g. as generated using
            normal_distribution.
-    
-    return: Array of len(x) containing the discrete cumulative values 
+
+    return: Array of len(x) containing the discrete cumulative values
             estimated using the integral under the provided PDF.
     """
     debug(f"Estimating CDF using {get_slug(x)}")
     if cdf_func=='gaussian': #If Gaussian, integrate under pdf
         pdf = normal_distribution(mu=mu, sigma=sigma, x=x)
         cdf = [np.trapz(pdf[:ii],x[:ii]) for ii in range(0,len(x))]
-    else: 
+    else:
         raise NotImplementedError
     return np.array(cdf)
 
@@ -124,7 +198,7 @@ def empirical_distribution(x, sample):
     Keyword arguments:
     x      -- Array of x-values over which to generate distribution
     sample -- Sample to use to generate distribution
-    
+
     return: Array of len(x) containing corresponding EDF values
     """
     debug(f"Estimating empirical distribution with {get_slug(x)}")

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -17,6 +17,9 @@ def quadratic_spline_roots(spl):
     A custom function for the roots of a quadratic spline. Cleverness found at
     https://stackoverflow.com/questions/50371298/find-maximum-minimum-of-a-1d-interpolated-function
     Used in find_maxima().
+
+    Example usage:
+    see example_scripts/tidegauge_tutorial.py
     """
     roots = []
     knots = spl.get_knots()
@@ -46,6 +49,9 @@ def find_maxima(x, y, method='comp', **kwargs):
             i) has ineligent fix for NaNs,
             ii) first converts x,y into np.floats64 for calc
             iii) probably assumes x,y are xr.DataArrays
+
+    Example usage:
+    see example_scripts/tidegauge_tutorial.py
     '''
     if method == 'comp':
         peaks, props = scipy.signal.find_peaks(y, **kwargs)

--- a/coast/stats_util.py
+++ b/coast/stats_util.py
@@ -95,13 +95,17 @@ def find_maxima(x, y, method='comp', **kwargs):
 
         # Do the interpolation
         f = scipy.interpolate.InterpolatedUnivariateSpline(x_float, y, k=3)
-        cr_pts = quadratic_spline_roots(f.derivative())
-        cr_vals = f(cr_pts)
-
+        # Find the extrema as roots
+        extr_x_vals = quadratic_spline_roots(f.derivative()) # x values of extrema
+        # Find the maxima roots
+        extr_x_vals = np.hstack( [x_float[0], extr_x_vals, x_float[-1]]) # add buffer points to ensure extrema are within
+        ind = scipy.signal.argrelmax( f(extr_x_vals) )[0] # index that gives max(f) over extrema x locations
+        max_vals = f(extr_x_vals[ind])
+        # Convert back to datetime64 if appropriate
         if flag_dt64:
-            return cr_pts.astype('datetime64'), cr_vals
+            return extr_x_vals[ind].astype('datetime64'), max_vals
         else:
-            return cr_pts, cr_vals
+            return extr_x_vals[ind], max_vals
 
 def doodson_x0_filter(elevation, ax=0):
     '''

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -133,7 +133,6 @@ date_end = np.datetime64('2020-10-14 00:01')
 # Initiate a TIDEGAUGE object, if a filename is passed it assumes it is a GESLA
 # type object
 tg = coast.TIDEGAUGE()
-# specify the data read as a High Low Water dataset
 tg.dataset = tg.read_bodc_to_xarray(fn_bodc, date_start, date_end)
 tg.plot_timeseries()
 
@@ -162,22 +161,32 @@ eg.plot_timeseries()
 #        Finds high and low water for a given variable.
 #        Returns in a new TIDEGAUGE object with similar data format to
 #        a TIDETABLE.
+# There are two methods for extracting extrema. A neightbour comparison method, 
+# (method="comp") and a cubic spline fitting method (method="cubic")
 
-# Data might need sorting by time
-eg.dataset =  eg.dataset.sortby(eg.dataset.time)
+date_start = np.datetime64('2020-10-13 20:00')
+date_end = np.datetime64('2020-10-13 21:01')
 
-# The extrema can be found as the by comparison of neighbouring time steps, 
-#  or by fitting cubic splines and finding the analytic extrema
-HLW_com = eg.find_high_and_low_water('sea_level',method='comp') # 'comp' is the default method
-HLW_cub = eg.find_high_and_low_water('sea_level',method='cubic') # 'comp' is the default method
+# Initiate a TIDEGAUGE object, if a filename is passed it assumes it is a GESLA
+# type object
+tg = coast.TIDEGAUGE()
+tg.dataset = tg.read_bodc_to_xarray(fn_bodc, date_start, date_end)
 
-import matplotlib.pyplot as plt
-plt.plot( eg.dataset.time, eg.dataset['sea_level'],'r.-', label='data')
-plt.plot( HLW_com.dataset.time_highs, HLW_com.dataset['sea_level_highs'],'k+', label='record extrema')
-plt.plot( HLW_com.dataset.time_lows, HLW_com.dataset['sea_level_lows'],'k+')
-plt.plot( HLW_cub.dataset.time_highs, HLW_cub.dataset['sea_level_highs'],'ko', label='cubic spline extrema')
-plt.plot( HLW_cub.dataset.time_lows, HLW_cub.dataset['sea_level_lows'],'ko')
-plt.legend()
-plt.show()
+# Use comparison of neighbourhood method (method="comp" is assumed)
+extrema_comp = tg.find_high_and_low_water('sea_level', method="comp")
+
+# Use cubic spline fitting method
+extrema_cubc = tg.find_high_and_low_water('sea_level', method="cubic")
+
+
+# Attempt a plot
+f = plt.figure()
+plt.plot(tg.dataset.time, tg.dataset.sea_level, 'k')
+plt.scatter(extrema_comp.dataset.time_highs.values, extrema_comp.dataset.sea_level_highs, marker='o', c='g')
+plt.scatter(extrema_cubc.dataset.time_highs.values, extrema_cubc.dataset.sea_level_highs, marker='+', c='g')
+
+plt.legend(['Time Series','Maxima by comparison','Maxima by cubic spline'])
+plt.title('Tide Gauge Optima at Gladstone')
+
 
 

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -157,3 +157,26 @@ eg.plot_timeseries()
 # (the default) station.
 eg.dataset = eg.read_EA_API_to_xarray(ndays=1, stationId="E70124")
 eg.plot_timeseries()
+
+#%% Tide table extrema can be extracted from the timeseries
+#        Finds high and low water for a given variable.
+#        Returns in a new TIDEGAUGE object with similar data format to
+#        a TIDETABLE.
+"""
+problem: existing find_high_and_low_water() method='comp' assumed tidetable input
+With method="cubic" it processes the complete timeseries to find the EXTREMA and 
+not the max
+"""
+
+# Data might need sorting by time
+eg.dataset =  eg.dataset.sortby(eg.dataset.time)
+
+HLW = eg.find_high_and_low_water('sea_level',method='cubic')
+
+import matplotlib.pyplot as plt
+plt.plot( eg.dataset.time, eg.dataset['sea_level'],'r.-', label='data')
+plt.plot( HLW.dataset.time_highs, HLW.dataset['sea_level_highs'],'k+', label='cubic spline extrema')
+plt.legend()
+plt.show()
+
+

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -162,20 +162,21 @@ eg.plot_timeseries()
 #        Finds high and low water for a given variable.
 #        Returns in a new TIDEGAUGE object with similar data format to
 #        a TIDETABLE.
-"""
-problem: existing find_high_and_low_water() method='comp' assumed tidetable input
-With method="cubic" it processes the complete timeseries to find the EXTREMA and 
-not the max
-"""
 
 # Data might need sorting by time
 eg.dataset =  eg.dataset.sortby(eg.dataset.time)
 
-HLW = eg.find_high_and_low_water('sea_level',method='cubic')
+# The extrema can be found as the by comparison of neighbouring time steps, 
+#  or by fitting cubic splines and finding the analytic extrema
+HLW_com = eg.find_high_and_low_water('sea_level',method='comp') # 'comp' is the default method
+HLW_cub = eg.find_high_and_low_water('sea_level',method='cubic') # 'comp' is the default method
 
 import matplotlib.pyplot as plt
 plt.plot( eg.dataset.time, eg.dataset['sea_level'],'r.-', label='data')
-plt.plot( HLW.dataset.time_highs, HLW.dataset['sea_level_highs'],'k+', label='cubic spline extrema')
+plt.plot( HLW_com.dataset.time_highs, HLW_com.dataset['sea_level_highs'],'k+', label='record extrema')
+plt.plot( HLW_com.dataset.time_lows, HLW_com.dataset['sea_level_lows'],'k+')
+plt.plot( HLW_cub.dataset.time_highs, HLW_cub.dataset['sea_level_highs'],'ko', label='cubic spline extrema')
+plt.plot( HLW_cub.dataset.time_lows, HLW_cub.dataset['sea_level_lows'],'ko')
 plt.legend()
 plt.show()
 

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -8,6 +8,7 @@ outlined in TIDEGAUGE.py.
 import coast
 import datetime
 import numpy as np
+import matplotlib.pyplot as plt
 
 # And by defining some file paths
 fn_nemo_dat  = './example_files/COAsT_example_NEMO_data.nc'
@@ -187,6 +188,6 @@ plt.scatter(extrema_cubc.dataset.time_highs.values, extrema_cubc.dataset.sea_lev
 
 plt.legend(['Time Series','Maxima by comparison','Maxima by cubic spline'])
 plt.title('Tide Gauge Optima at Gladstone')
-
+plt.show()
 
 

--- a/example_scripts/tidegauge_tutorial.py
+++ b/example_scripts/tidegauge_tutorial.py
@@ -119,25 +119,6 @@ for tg in tidegauge_list:
 fig, ax = TIDEGAUGE.plot_on_map_multiple(tidegauge_list, color_var_str='rmse')
 
 
-#%%  Additionally, alternative data streams can be read in and similarly
-# processed. For example the BODC processed data from the UK Tidegauge network.
-# Data name: UK Tide Gauge Network, processed data.
-# Source: https://www.bodc.ac.uk/
-
-# Load and plot BODC processed data
-fn_bodc = 'example_files/LIV2010.txt'
-
-# Set the start and end dates
-date_start = np.datetime64('2020-10-12 23:59')
-date_end = np.datetime64('2020-10-14 00:01')
-
-# Initiate a TIDEGAUGE object, if a filename is passed it assumes it is a GESLA
-# type object
-tg = coast.TIDEGAUGE()
-tg.dataset = tg.read_bodc_to_xarray(fn_bodc, date_start, date_end)
-tg.plot_timeseries()
-
-
 #%% Alternatively load in data obtained using the Environment Agency (England)
 #  API. These are only accessible for the last 28 days. This does not require
 # an API key.
@@ -158,6 +139,11 @@ eg.plot_timeseries()
 eg.dataset = eg.read_EA_API_to_xarray(ndays=1, stationId="E70124")
 eg.plot_timeseries()
 
+#%%  Additionally, alternative data streams can be read in and similarly
+# processed. For example the BODC processed data from the UK Tidegauge network.
+# Data name: UK Tide Gauge Network, processed data.
+# Source: https://www.bodc.ac.uk/
+
 #%% Tide table extrema can be extracted from the timeseries
 #        Finds high and low water for a given variable.
 #        Returns in a new TIDEGAUGE object with similar data format to
@@ -165,11 +151,16 @@ eg.plot_timeseries()
 # There are two methods for extracting extrema. A neightbour comparison method, 
 # (method="comp") and a cubic spline fitting method (method="cubic")
 
+# Load and plot BODC processed data
+fn_bodc = 'example_files/LIV2010.txt'
+
+# Set the start and end dates
 date_start = np.datetime64('2020-10-13 20:00')
-date_end = np.datetime64('2020-10-13 21:01')
+date_end = np.datetime64('2020-10-13 21:00')
 
 # Initiate a TIDEGAUGE object, if a filename is passed it assumes it is a GESLA
 # type object
+del tg
 tg = coast.TIDEGAUGE()
 tg.dataset = tg.read_bodc_to_xarray(fn_bodc, date_start, date_end)
 
@@ -179,13 +170,13 @@ extrema_comp = tg.find_high_and_low_water('sea_level', method="comp")
 # Use cubic spline fitting method
 extrema_cubc = tg.find_high_and_low_water('sea_level', method="cubic")
 
-
-# Attempt a plot
-f = plt.figure()
+# Plot to show the difference between maxima find methods for high tide example.
+plt.figure()
 plt.plot(tg.dataset.time, tg.dataset.sea_level, 'k')
 plt.scatter(extrema_comp.dataset.time_highs.values, extrema_comp.dataset.sea_level_highs, marker='o', c='g')
 plt.scatter(extrema_cubc.dataset.time_highs.values, extrema_cubc.dataset.sea_level_highs, marker='+', c='g')
-
+plt.xlim([date_start, date_end])
+plt.ylim([7.75, 8.0])
 plt.legend(['Time Series','Maxima by comparison','Maxima by cubic spline'])
 plt.title('Tide Gauge Optima at Gladstone')
 plt.show()

--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -284,7 +284,7 @@ subsec = subsec+1
 # NEMO obejct and dataset.
 
 try:
-    harmonics = coast.NEMO(dn_files + fn_nemo_harmonics, 
+    harmonics = coast.NEMO(dn_files + fn_nemo_harmonics,
                            dn_files + fn_nemo_harmonics_dom)
     constituents = ['K1','M2','S2','K2']
     harmonics_combined = harmonics.harmonics_combine(constituents)
@@ -299,7 +299,7 @@ try:
 
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
-    
+
 #-----------------------------------------------------------------------------#
 #%% ( 1j ) Convert harmonics to a/g and back                                  #
 #                                                                             #
@@ -1253,7 +1253,7 @@ except:
     print(str(sec) + chr(subsec) +' FAILED.')
 
 #-----------------------------------------------------------------------------#
-#%% ( 7n ) TIDEGAUGE method for finding extrema and troughs                   #
+#%% ( 7n ) TIDEGAUGE method for finding extrema and troughs, compare neighbours#
 #                                                                             #
 subsec = subsec+1
 
@@ -1264,30 +1264,74 @@ try:
     lowestoft2 = coast.TIDEGAUGE(fn_tidegauge, date_start = date0,
                                 date_end = date1)
 
-    extrema = lowestoft2.find_high_and_low_water('sea_level', distance=40)
-
+    # Use comparison of neighbourhood method (method="comp" is assumed)
+    extrema_comp = lowestoft2.find_high_and_low_water('sea_level', distance=40)
     # Check actual maximum/minimum is in output dataset
-    check1 = np.nanmax(lowestoft2.dataset.sea_level) in extrema.dataset.sea_level_highs
-    check2 = np.nanmin(lowestoft2.dataset.sea_level) in extrema.dataset.sea_level_lows
+    check1 = np.nanmax(lowestoft2.dataset.sea_level) in extrema_comp.dataset.sea_level_highs
+    check2 = np.nanmin(lowestoft2.dataset.sea_level) in extrema_comp.dataset.sea_level_lows
     # Check new time dimensions have correct length (hardcoded here)
-    check3 = len(extrema.dataset.time_highs) == 19
-    check4 = len(extrema.dataset.time_lows) == 18
+    check3 = len(extrema_comp.dataset.time_highs) == 19
+    check4 = len(extrema_comp.dataset.time_lows) == 18
 
     # Attempt a plot
     f = plt.figure()
     plt.plot(lowestoft2.dataset.time, lowestoft2.dataset.sea_level)
-    plt.scatter(extrema.dataset.time_highs, extrema.dataset.sea_level_highs, c='g')
-    plt.scatter(extrema.dataset.time_lows, extrema.dataset.sea_level_lows, c='r')
+    plt.scatter(extrema_comp.dataset.time_highs.values, extrema_comp.dataset.sea_level_highs, marker='o', c='g')
+    plt.scatter(extrema_comp.dataset.time_lows.values,  extrema_comp.dataset.sea_level_lows, marker='o', c='r')
+
     plt.legend(['Time Series','Maxima','Minima'])
     plt.title('Tide Gauge Optima at Lowestoft')
     f.savefig(dn_fig + 'tidegauge_optima.png')
 
     if check1 and check2 and check3 and check4:
-        print(str(sec) + chr(subsec) + " OK - Tidegauge extrema found")
+        print(str(sec) + chr(subsec) + " OK - Tidegauge local extrema found")
     else:
-        print(str(sec) + chr(subsec) + " X - Tidegauge extrema")
+        print(str(sec) + chr(subsec) + " X - Tidegauge local extrema")
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
+
+
+#-----------------------------------------------------------------------------#
+#%% ( 7o ) TIDEGAUGE method for finding extrema and troughs, fit cubic spline #
+#                                                                             #
+subsec = subsec+1
+
+# Load and process BODC processed data
+try:
+    # Set the start and end dates
+    date_start = np.datetime64('2020-10-12 23:59')
+    date_end = np.datetime64('2020-10-14 00:01')
+
+    # Initiate a TIDEGAUGE object, if a filename is passed it assumes it is a GESLA
+    # type object
+    tg = coast.TIDEGAUGE()
+    # specify the data read as a High Low Water dataset
+    tg.dataset = tg.read_bodc_to_xarray(fn_tidegauge2, date_start, date_end)
+
+    # Use cubic spline fitting method
+    extrema_cubc = tg.find_high_and_low_water('sea_level', method="cubic")
+
+    # Check actual maximum/minimum is in output dataset
+    check1 = np.isclose( extrema_cubc.dataset.sea_level_highs,[7.77432795, 7.91244559])
+    check2 = np.isclose( extrema_cubc.dataset.sea_level_lows,[2.63479458, 2.54599355])
+                                
+    # Attempt a plot
+    f = plt.figure()
+    plt.plot(tg.dataset.time, tg.dataset.sea_level)
+    plt.scatter(extrema_cubc.dataset.time_highs.values, extrema_cubc.dataset.sea_level_highs, marker='o', c='g')
+    plt.scatter(extrema_cubc.dataset.time_lows.values,  extrema_cubc.dataset.sea_level_lows, marker='o', c='r')
+
+    plt.legend(['Time Series','Maxima','Minima'])
+    plt.title('Tide Gauge Optima at Gladstone, fitted cubic spline')
+    f.savefig(dn_fig + 'tidegauge_optima.png')
+
+    if check1.all() and check2.all():
+        print(str(sec) + chr(subsec) + " OK - Tidegauge cubic extrema found")
+    else:
+        print(str(sec) + chr(subsec) + " X - Tidegauge cubic extrema")
+except:
+    print(str(sec) + chr(subsec) +' FAILED.')
+
 
 '''
 ###############################################################################
@@ -1527,7 +1571,7 @@ try:
 
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
-    
+
 
 #-----------------------------------------------------------------------------#
 # ( 11b ) Plot locations on map                                               #
@@ -1542,7 +1586,7 @@ try:
     print(str(sec) + chr(subsec) + " OK - Profiles map plot saved")
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
-    
+
 #-----------------------------------------------------------------------------#
 # ( 11c ) Plot ts diagram                                                     #
 #                                                                             #
@@ -1556,7 +1600,7 @@ try:
     print(str(sec) + chr(subsec) + " OK - Profiles ts diagram plot saved")
 except:
     print(str(sec) + chr(subsec) +' FAILED.')
-    
+
 #-----------------------------------------------------------------------------#
 # ( 11d ) Plot temperature profile                                            #
 #                                                                             #

--- a/unit_testing/unit_test_contents.txt
+++ b/unit_testing/unit_test_contents.txt
@@ -13,9 +13,9 @@
     f. Calculate depth_0 for t,u,v,w,f grids
     g. Load a subregion dataset with a full domain (AMM7)
     h. Load and combine multiple files.
-    i. Load and combine harmonics 
-    j. Convert harmonics to a/g and back 
-    
+    i. Load and combine harmonics
+    j. Convert harmonics to a/g and back
+
 2. General Utility Methods in COAsT
     a. Copying a COAsT object
     b. COAsT __getitem__ returns variable
@@ -64,7 +64,8 @@
     k. Plotting multiple tidegauge locations
     l. Tidegauge time series plot
     m. TIDEGAUGE method for tabulated data
-    n. TIDEGAUGE method for finding peaks and troughs
+    n. TIDEGAUGE method for finding peaks and troughs, compare neighbours
+    o. TIDEGAUGE method for finding extrema and troughs, fit cubic spline
 
 8. Isobath Contour Methods
     a. Extract isbath contour between two points


### PR DESCRIPTION
**UPDATED**
Find an analytic approx to timeseries maxima by fitting cubic splines and doing some calculus.
See (https://github.com/British-Oceanographic-Data-Centre/COAsT/issues/259)

Usage appears in the [last section](https://github.com/British-Oceanographic-Data-Centre/COAsT/blob/feature/extrema_on_spline/example_scripts/tidegauge_tutorial.py) in the tidegauge_tutorial.py on the Liverpool timeseries from the BODC.

Also added as unit test 7o.

Fixed the 'issue' about returning max and mins. Now only returns maxima, following Anthony's recommendation. 

AC:
- [ ] New unit testing works (I.e. 7o)
- [ ] tidegauge_tutorial.py works (i.e. completes unit test 10a)