### PR TITLE
0242/transports using e3u v

### DIFF
--- a/coast/CONTOUR.py
+++ b/coast/CONTOUR.py
@@ -147,7 +147,7 @@ class Contour:
         '''
         Class defining a Contour type, which is a 3d dataset of points between a point A and 
         a point B defining an isobath contour. The dataset has a time, depth and contour dimension. 
-        The cotnour dimension defines the points along the contour.
+        The contour dimension defines the points along the contour.
         The supplied model Data is subsetted in its entirety along these dimensions and
         calculations can be performed on this dataset.
         
@@ -297,6 +297,10 @@ class Contour_f(Contour):
         (time, depth, position along contour) in m/s
         Contour_f.depth_integrated_normal_transport are the depth integrated 
         volume transports across the contour (time, position along contour) in Sv
+        
+        If the time dependent cell thicknesses (e3) on the u and v grids are 
+        present in the nemo_u and nemo_v datasets they will be used, if they 
+        are not then the initial cell thicknesses (e3_0) will be used.
 
         Parameters
         ----------

--- a/coast/CONTOUR.py
+++ b/coast/CONTOUR.py
@@ -687,7 +687,7 @@ class Contour_f(Contour):
         self.data_cross_flow['normal_velocity_spg'] = xr.DataArray( np.squeeze(normal_velocity_spg),
                 coords=coords_spg, dims=dims_spg, attrs=attributes_spg)
         self.data_cross_flow['transport_across_AB_hpg'] = ( self.data_cross_flow
-                .normal_velocity_hpg.fillna(0).integrate(coord='depth_z_levels') ) * e_horiz / 1000000   
+                .normal_velocity_hpg.fillna(0).integrate(dim='depth_z_levels') ) * e_horiz / 1000000   
         self.data_cross_flow.transport_across_AB_hpg.attrs = {'units': 'Sv', 
                 'standard_name': 'volume transport across transect due to the hydrostatic pressure gradient'}        
         self.data_cross_flow['transport_across_AB_spg'] = self.data_cross_flow.normal_velocity_spg * H * e_horiz / 1000000

--- a/coast/CONTOUR.py
+++ b/coast/CONTOUR.py
@@ -327,22 +327,22 @@ class Contour_f(Contour):
         
         # Note that subsetting the dataset first instead of subsetting each array seperately,
         # as we do here, is neater but significantly slower.
-        self.data_cross_flow['normal_velocities'] = xr.full_like(u_ds.vozocrtx, np.nan)        
-        self.data_cross_flow['normal_velocities'][:,:,dr_n] = u_ds.vozocrtx.data[:,:,dr_n+1]
-        self.data_cross_flow['normal_velocities'][:,:,dr_s] = -u_ds.vozocrtx.data[:,:,dr_s]
-        self.data_cross_flow['normal_velocities'][:,:,dr_e] = -v_ds.vomecrty.data[:,:,dr_e+1]
-        self.data_cross_flow['normal_velocities'][:,:,dr_w] = v_ds.vomecrty.data[:,:,dr_w]
+        self.data_cross_flow['normal_velocities'] = xr.full_like(u_ds.u_velocity, np.nan)        
+        self.data_cross_flow['normal_velocities'][:,:,dr_n] = u_ds.u_velocity.data[:,:,dr_n+1]
+        self.data_cross_flow['normal_velocities'][:,:,dr_s] = -u_ds.u_velocity.data[:,:,dr_s]
+        self.data_cross_flow['normal_velocities'][:,:,dr_e] = -v_ds.v_velocity.data[:,:,dr_e+1]
+        self.data_cross_flow['normal_velocities'][:,:,dr_w] = v_ds.v_velocity.data[:,:,dr_w]
         self.data_cross_flow['normal_velocities'].attrs = {'units':'m/s', \
                 'standard_name':'contour-normal velocities'}
              
-        self.data_cross_flow['normal_transport'] = xr.full_like(u_ds.vozocrtx, np.nan)  
-        self.data_cross_flow['normal_transport'][:,:,dr_n] = ( u_ds.vozocrtx.data[:,:,dr_n+1] * 
+        self.data_cross_flow['normal_transport'] = xr.full_like(u_ds.u_velocity, np.nan)  
+        self.data_cross_flow['normal_transport'][:,:,dr_n] = ( u_ds.u_velocity.data[:,:,dr_n+1] * 
                                 u_ds.e2.data[dr_n+1] * u_ds.e3_0.data[:,dr_n+1] )
-        self.data_cross_flow['normal_transport'][:,:,dr_s] = ( -u_ds.vozocrtx.data[:,:,dr_s] * 
+        self.data_cross_flow['normal_transport'][:,:,dr_s] = ( -u_ds.u_velocity.data[:,:,dr_s] * 
                                 u_ds.e2.data[dr_s] * u_ds.e3_0.data[:,dr_s] )
-        self.data_cross_flow['normal_transport'][:,:,dr_e] = ( -v_ds.vomecrty.data[:,:,dr_e+1] *
+        self.data_cross_flow['normal_transport'][:,:,dr_e] = ( -v_ds.v_velocity.data[:,:,dr_e+1] *
                                 v_ds.e1.data[dr_e+1] * v_ds.e3_0.data[:,dr_e+1] )
-        self.data_cross_flow['normal_transport'][:,:,dr_w] = ( v_ds.vomecrty.data[:,:,dr_w] *
+        self.data_cross_flow['normal_transport'][:,:,dr_w] = ( v_ds.v_velocity.data[:,:,dr_w] *
                                 v_ds.e1.data[dr_w] * v_ds.e3_0.data[:,dr_w] )
         self.data_cross_flow['normal_transport'].attrs = {'units':'m^3/s', \
                 'standard_name':'contour-normal volume transport'}

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -85,7 +85,10 @@ class NEMO(COAsT):  # TODO Complete this docstring
                             'toce' : 'temperature',
                             'so' : 'salinity',
                             'vosaline' : 'salinity',
-                            'voce' : 'salinity',
+                            'voce' : 'v_velocity',
+                            'vomecrty' : 'v_velocity',
+                            'uoce' : 'u_velocity',
+                            'vozocrtx' : 'u_velocity',
                             'sossheig' : 'ssh',
                             'zos' : 'ssh' }
         # Variable names mapped from domain to NEMO object

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -683,6 +683,8 @@ class NEMO(COAsT):  # TODO Complete this docstring
         except AttributeError:
             print('The nemo_t dataset must contain the ssh variable.')
             return
+        if 't_dim' not in ssh.dims:
+            ssh = ssh.expand_dims('t_dim', axis=0)
 
         # Load domain_cfg
         if dom_fn is None:
@@ -707,7 +709,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
         # preserve any other t mask
         e3t_new = e3t_new.where(~np.isnan(ssh))
         if e3t:
-            e3_return.append(e3t_new)
+            e3_return.append(e3t_new.squeeze())
         
         if np.any([e3u,e3v,e3f]):
             e1e2t = ds_dom.e1t * ds_dom.e2t
@@ -733,7 +735,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
             e3u_new['longitude'] = ds_dom.glamu
             e3u_new['latitude'] = ds_dom.gphiu
             if e3u:
-                e3_return.append(e3u_new)
+                e3_return.append(e3u_new.squeeze())
         
         # area averaged interpolation onto the u-grid to get e3v 
         if e3v:
@@ -749,7 +751,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
             e3v_new[:,:,-1,:] = ds_dom.e3v_0[:,-1,:]
             e3v_new['longitude'] = ds_dom.glamv
             e3v_new['latitude'] = ds_dom.gphiv
-            e3_return.append(e3v_new)
+            e3_return.append(e3v_new.squeeze())
         
         # area averaged interpolation onto the u-grid to get e3f
         if e3f:
@@ -766,7 +768,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
             e3f_new[:,:,-1,:] = ds_dom.e3f_0[:,-1,:]
             e3f_new['longitude'] = ds_dom.glamf
             e3f_new['latitude'] = ds_dom.gphif
-            e3_return.append(e3f_new)
+            e3_return.append(e3f_new.squeeze())
            
         # simple vertical interpolation for e3w. Special treatment of top and bottom levels   
         if e3w:
@@ -778,7 +780,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
                                     + ds_dom.e3w_0[1:,:,:] )
             # bottom and below levels
             e3w_new = e3w_new.where(e3w_new.z_dim<ds_dom.bottom_level, e3t_dt.shift(z_dim=1) + ds_dom.e3w_0)
-            e3_return.append(e3w_new)
+            e3_return.append(e3w_new.squeeze())
             
         return tuple(e3_return)
             

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -85,6 +85,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
                             'toce' : 'temperature',
                             'so' : 'salinity',
                             'vosaline' : 'salinity',
+                            'soce' : 'salinity',
                             'voce' : 'v_velocity',
                             'vomecrty' : 'v_velocity',
                             'uoce' : 'u_velocity',

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -727,7 +727,8 @@ class NEMO(COAsT):  # TODO Complete this docstring
             e3u_new[:,:,:,-1] = ds_dom.e3u_0[:,:,-1]
             e3u_new['longitude'] = ds_dom.glamu
             e3u_new['latitude'] = ds_dom.gphiu
-            e3_return.append(e3u_new)
+            if e3u:
+                e3_return.append(e3u_new)
         
         # area averaged interpolation onto the u-grid to get e3v 
         if e3v:

--- a/coast/NEMO.py
+++ b/coast/NEMO.py
@@ -634,9 +634,44 @@ class NEMO(COAsT):  # TODO Complete this docstring
         if filtered is not None:
             self.dataset[new_var_str] = (old_dims, filtered)
         return
-        
+       
+    
     @staticmethod
-    def get_e3_from_ssh(nemo_t, e3u=False, e3v=False, e3f=False, e3w=False, dom_fn:str=None):
+    def get_e3_from_ssh(nemo_t, e3t=True, e3u=False, e3v=False, e3f=False, 
+                        e3w=False, dom_fn:str=None):
+        '''
+        Where the model has been run with a nonlinear free surface
+        and z* variable volumne (ln_vvl_zstar=True) then the vertical scale factors
+        will vary in time (and space). This function will compute the vertical
+        scale factors e3t, e3u, e3v, e3f and e3w by using the sea surface height
+        field (ssh variable) and initial scale factors from the domain_cfg file.
+        The vertical scale factors will be computed at the same model time as the 
+        ssh and if the ssh field is averaged in time then the scale factors will
+        also be time averages. 
+        
+        A t-grid NEMO object containing the ssh variable must be passed in. Either 
+        the domain_cfg path must have been passed in as an argument when the NEMO 
+        object was created or it must be passed in here using the dom_fn argument.
+        
+        e.g. e3t,e3v,e3f = coast.NEMO.get_e3_from_ssh(nemo_t,true,false,true,true,false)
+        
+        Parameters
+        ----------
+        nemo_t : (COAsT.NEMO), NEMO object on the t-grid containing the ssh variable
+        e3t : (boolean), true if e3t is to be returned. Default True.
+        e3u : (boolean), true if e3u is to be returned. Default False.
+        e3v : (boolean), true if e3v is to be returned. Default False.
+        e3f : (boolean), true if e3f is to be returned. Default False.
+        e3w : (boolean), true if e3w is to be returned. Default False.
+        dom_fn : (str), Optional, path to domain_cfg file. 
+
+        Returns
+        -------
+        Tuple of xarray.DataArrays
+        (e3t, e3u, e3v, e3f, e3w)
+        Only those requested will be returned, but the ordering is always the same.
+
+        '''
         e3_return = []
         try:
             ssh = nemo_t.dataset.ssh
@@ -644,6 +679,7 @@ class NEMO(COAsT):  # TODO Complete this docstring
             print('The nemo_t dataset must contain the ssh variable.')
             return
 
+        # Load domain_cfg
         if dom_fn is None:
             dom_fn = nemo_t.filename_domain
         try:
@@ -653,43 +689,89 @@ class NEMO(COAsT):  # TODO Complete this docstring
             print(f'Problem opening domain_cfg file: {dom_fn}')
             return 
             
-        e3t_0 = ds_dom.e3_0
+        e3t_0 = ds_dom.e3t_0
     
         # Water column thickness, i.e. depth of bottom w-level on horizontal t-grid
         H = e3t_0.cumsum(dim='z_dim').isel(z_dim=ds_dom.bottom_level-1)
-        e3t_new = e3t_0.data * ( 1 + ssh.expand_dims(dim={'z_dim':e3t_0.z_dim.data},axis=1) / H.data )
+        # Add correction to e3t_0 due to change in ssh
+        e3t_new = e3t_0 * ( 1 + ssh / H )
+        # preserve dimension ordering
+        e3t_new = e3t_new.transpose('t_dim','z_dim','y_dim','x_dim')
+        # mask out correction at layers below bottom level
         e3t_new = e3t_new.where(e3t_new.z_dim<ds_dom.bottom_level,e3t_0.data)
-        e3_return.append(e3t_new)
+        # preserve any other t mask
+        e3t_new = e3t_new.where(~xr.ufuncs.isnan(ssh))
+        if e3t:
+            e3_return.append(e3t_new)
         
         if np.any([e3u,e3v,e3f]):
             e1e2t = ds_dom.e1t * ds_dom.e2t
         if np.any([e3u,e3v,e3w]):
             e3t_dt = e3t_new - e3t_0
             
+        # area averaged interpolation onto the u-grid to get e3u    
         if np.any([e3u,e3f]):           
-            e1e2u = ds_dom.e1u * ds_dom.e2u
-            e3u_new = ( (0.5/e1e2u) * ( (e1e2t * e3t_dt)[:,:,:-1] 
-                    + (e1e2t * e3t_dt)[:,:,1:] ) + ds_dom.e3u_0[:,:,:-1] )
+            e1e2u = ds_dom.e1u * ds_dom.e2u  
+            # interpolate onto u-grid
+            e3u_temp = ( ( (0.5/e1e2u[:,:-1]) * ( (e1e2t[:,:-1] * e3t_dt[:,:,:,:-1]) 
+                    + (e1e2t[:,1:] * e3t_dt[:,:,:,1:]) ) )
+                    .transpose('t_dim','z_dim','y_dim','x_dim') )
+            # u mask
+            e3u_temp = e3u_temp.where(e3t_dt[:,:,:,1:]!=0, 0)
+            # mask out correction at layers below bottom level
+            e3u_temp = e3u_temp.where(e3u_temp.z_dim<ds_dom.bottom_level[:,:-1], 0)
+            # Add correction to e3u_0
+            e3u_temp = ( e3u_temp + ds_dom.e3u_0[:,:,:-1] )
+            e3u_new = xr.zeros_like(e3t_new)
+            e3u_new[:,:,:,:-1] = e3u_temp
+            e3u_new[:,:,:,-1] = ds_dom.e3u_0[:,:,-1]
+            e3u_new['longitude'] = ds_dom.glamu
+            e3u_new['latitude'] = ds_dom.gphiu
             e3_return.append(e3u_new)
         
+        # area averaged interpolation onto the u-grid to get e3v 
         if e3v:
             e1e2v = ds_dom.e1v * ds_dom.e2v
-            e3v_new = ( (0.5/e1e2v) * ( (e1e2t * e3t_dt)[:,:-1,:] 
-                    + (e1e2t * e3t_dt)[:,1:,:] ) + ds_dom.e3u_0[:,:-1,:] )
+            e3v_temp = ( ( (0.5/e1e2v[:-1,:]) * ( (e1e2t[:-1,:] * e3t_dt[:,:,:-1,:]) 
+                    + (e1e2t[1:,:] * e3t_dt[:,:,1:,:]) ) )
+                    .transpose('t_dim','z_dim','y_dim','x_dim') )
+            e3v_temp = e3v_temp.where(e3t_dt[:,:,1:,:]!=0, 0)
+            e3v_temp = e3v_temp.where(e3v_temp.z_dim<ds_dom.bottom_level[:-1,:], 0)
+            e3v_temp = ( e3v_temp + ds_dom.e3v_0[:,:-1,:] )
+            e3v_new = xr.zeros_like(e3t_new)
+            e3v_new[:,:,:-1,:] = e3v_temp
+            e3v_new[:,:,-1,:] = ds_dom.e3v_0[:,-1,:]
+            e3v_new['longitude'] = ds_dom.glamv
+            e3v_new['latitude'] = ds_dom.gphiv
             e3_return.append(e3v_new)
         
+        # area averaged interpolation onto the u-grid to get e3f
         if e3f:
             e1e2f = ds_dom.e1f * ds_dom.e2f
             e3u_dt = e3u_new - ds_dom.e3u_0
-            e3f_new = ( (0.5/e1e2f) * ( (e1e2u * e3u_dt)[:,:-1,:] 
-                    + (e1e2u * e3u_dt)[:,1:,:] ) + ds_dom.e3u_0[:,:-1,:] )
+            e3f_temp = ( ( (0.5/e1e2f[:-1,:]) * ( (e1e2u[:-1,:] * e3u_dt[:,:,:-1,:]) 
+                    + (e1e2u[1:,:] * e3u_dt[:,:,1:,:] ) ) )
+                    .transpose('t_dim','z_dim','y_dim','x_dim') )
+            e3f_temp = e3f_temp.where(e3u_dt[:,:,1:,:]!=0, 0)
+            e3f_temp = e3f_temp.where(e3f_temp.z_dim<ds_dom.bottom_level[:-1,:], 0)        
+            e3f_temp = ( e3f_temp + ds_dom.e3f_0[:,:-1,:] )
+            e3f_new = xr.zeros_like(e3t_new)
+            e3f_new[:,:,:-1,:] = e3f_temp
+            e3f_new[:,:,-1,:] = ds_dom.e3f_0[:,-1,:]
+            e3f_new['longitude'] = ds_dom.glamf
+            e3f_new['latitude'] = ds_dom.gphif
             e3_return.append(e3f_new)
-            
+           
+        # simple vertical interpolation for e3w. Special treatment of top and bottom levels   
         if e3w:
-            e3w_new = ds_dom.e3w_0 + e3t_dt
+            # top levels correction same at e3t
+            e3w_new = (ds_dom.e3w_0 + e3t_dt).transpose('t_dim','z_dim','y_dim','x_dim')
+            # levels between top and bottom
             e3w_new[dict(z_dim=slice(1,None))] = ( 0.5*e3t_dt[:,:-1,:,:] 
                                     + 0.5*e3t_dt[:,1:,:,:] 
-                                    + ds_dom.e3w_0[:,:-1,:,:] )
+                                    + ds_dom.e3w_0[1:,:,:] )
+            # bottom and below levels
+            e3w_new = e3w_new.where(e3w_new.z_dim<ds_dom.bottom_level, e3t_dt.shift(z_dim=1) + ds_dom.e3w_0)
             e3_return.append(e3w_new)
             
         return tuple(e3_return)

--- a/coast/TRANSECT.py
+++ b/coast/TRANSECT.py
@@ -9,6 +9,7 @@ from scipy.integrate import cumtrapz
 from .logging_util import get_slug, debug, error
 import warnings
 import traceback
+from .logging_util import get_slug, debug, info, warn, error
 
 # =============================================================================
 # The TRANSECT module is a place for code related to transects only
@@ -286,7 +287,9 @@ class Transect_f(Transect):
         super().__init__(nemo_f, point_A, point_B, y_indices, x_indices)
         
         
-    def calc_flow_across_transect(self, nemo_u: COAsT, nemo_v: COAsT):
+    def calc_flow_across_transect(self, nemo_u: COAsT, nemo_v: COAsT): 
+        #TODO the code here has become a little messy, could do with being 
+        # rewritten as in similar function in CONTOUR
         """
     
         Computes the flow through the transect at each segment and creates a new 
@@ -299,6 +302,10 @@ class Transect_f(Transect):
         The latitude, longitude and the horizontal and vertical scale factors
         on the normal velocity points are also stored in the dataset.
         
+        If the time dependent cell thicknesses (e3) on the u and v grids are 
+        present in the nemo_u and nemo_v datasets they will be used, if they 
+        are not then the initial cell thicknesses (e3_0) will be used.
+        
         parameters
         ----------
         nemo_u : Nemo object on the u-grid containing the i-component velocities
@@ -306,6 +313,9 @@ class Transect_f(Transect):
         
         """
         debug(f"Computing flow across the transect for {get_slug(self)}")
+        
+        # compute transports flag; set to false if suitable e3 not found
+        compute_transports = True
                 
         # subset the u and v datasets 
         da_y_ind = xr.DataArray( self.y_ind, dims=['r_dim'] )
@@ -313,14 +323,32 @@ class Transect_f(Transect):
         u_ds = nemo_u.dataset.isel(y_dim = da_y_ind, x_dim = da_x_ind)
         v_ds = nemo_v.dataset.isel(y_dim = da_y_ind, x_dim = da_x_ind)
         
+        # use time varying if e3 is present, if not default to e3_0
+        if 'e3' not in u_ds.data_vars:
+            if 'e3_0' not in u_ds.data_vars:
+                warn("e3 not found, transports will not be calculated")
+                compute_transports = False
+            else:
+                u_ds['e3'] = u_ds.e3_0.broadcast_like(u_ds.u_velocity) 
+        if 'e3' not in v_ds.data_vars:
+            if 'e3_0' not in v_ds.data_vars:
+                warn("e3 not found, transports will not be calculated")
+                compute_transports = False
+            else:
+                v_ds['e3'] = v_ds.e3_0.broadcast_like(v_ds.v_velocity) 
+        
         # If there is no time dimension, add one. This is so
         # indexing can assume a time dimension exists
         droptime=False
         if 't_dim' not in u_ds.dims:
             u_ds["u_velocity"] = u_ds.u_velocity.expand_dims(dim={'t_dim':1},axis=0)
+            if compute_transports:
+                u_ds["e3"] = u_ds.e3.expand_dims(dim={'t_dim':1},axis=0)
             droptime=True
         if 't_dim' not in v_ds.dims:
             v_ds["v_velocity"] = v_ds.v_velocity.expand_dims(dim={'t_dim':1},axis=0)
+            if compute_transports:
+                v_ds["e3"] = v_ds.e3.expand_dims(dim={'t_dim':1},axis=0)
         
         velocity = np.ma.zeros( (u_ds.t_dim.size, u_ds.z_dim.size, u_ds.r_dim.size-1) )
         vol_transport = np.ma.zeros( (u_ds.t_dim.size, u_ds.z_dim.size, u_ds.r_dim.size-1) )
@@ -329,7 +357,7 @@ class Transect_f(Transect):
         longitude = np.ma.zeros( (u_ds.r_dim.size-1) )
         e1 = np.ma.zeros( (u_ds.r_dim.size-1) )
         e2 = np.ma.zeros( (u_ds.r_dim.size-1) )
-        e3_0 = np.ma.zeros( (u_ds.z_dim.size, u_ds.r_dim.size-1) )
+        e3 = np.ma.zeros( (u_ds.t_dim.size, u_ds.z_dim.size, u_ds.r_dim.size-1) )
         
         # Find the indices where the derivative of the transect in the north, south, east and west
         # directions are positive.
@@ -342,44 +370,48 @@ class Transect_f(Transect):
         
         # u flux (+ in)
         velocity[:,:,dr_n] = u_ds.u_velocity.to_masked_array()[:,:,dr_n+1]
-        vol_transport[:,:,dr_n] = ( velocity[:,:,dr_n] * u_ds.e2.to_masked_array()[dr_n+1] *
-                                          u_ds.e3_0.to_masked_array()[:,dr_n+1] )
+        if compute_transports:
+            vol_transport[:,:,dr_n] = ( velocity[:,:,dr_n] * u_ds.e2.to_masked_array()[dr_n+1] *
+                                          u_ds.e3.to_masked_array()[:,:,dr_n+1] )
+            e3[:,:,dr_n] = u_ds.e3.values[:,:,dr_n+1]
         depth_0[:,dr_n] = u_ds.depth_0.to_masked_array()[:,dr_n+1]
         latitude[dr_n] = u_ds.latitude.values[dr_n+1]
         longitude[dr_n] = u_ds.longitude.values[dr_n+1]
         e1[dr_n] = u_ds.e1.values[dr_n+1]
         e2[dr_n] = u_ds.e2.values[dr_n+1]
-        e3_0[:,dr_n] = u_ds.e3_0.values[:,dr_n+1]
-        
+               
         # v flux (- in) 
         velocity[:,:,dr_e] = - v_ds.v_velocity.to_masked_array()[:,:,dr_e+1]
-        vol_transport[:,:,dr_e] = ( velocity[:,:,dr_e] * v_ds.e1.to_masked_array()[dr_e+1] *
-                                  v_ds.e3_0.to_masked_array()[:,dr_e+1] )
+        if compute_transports:
+            vol_transport[:,:,dr_e] = ( velocity[:,:,dr_e] * v_ds.e1.to_masked_array()[dr_e+1] *
+                                  v_ds.e3.to_masked_array()[:,:,dr_e+1] )
+            e3[:,:,dr_e] = v_ds.e3.values[:,:,dr_e+1]
         depth_0[:,dr_e] = v_ds.depth_0.to_masked_array()[:,dr_e+1]
         latitude[dr_e] = v_ds.latitude.values[dr_e+1]
         longitude[dr_e] = v_ds.longitude.values[dr_e+1]
         e1[dr_e] = v_ds.e1.values[dr_e+1]
         e2[dr_e] = v_ds.e2.values[dr_e+1]
-        e3_0[:,dr_e] = v_ds.e3_0.values[:,dr_e+1]
-        
+               
         # v flux (+ in)
         velocity[:,:,dr_w] = v_ds.v_velocity.to_masked_array()[:,:,dr_w]
-        vol_transport[:,:,dr_w] = ( velocity[:,:,dr_w] * v_ds.e1.to_masked_array()[dr_w] *
-                                  v_ds.e3_0.to_masked_array()[:,dr_w] )
+        if compute_transports:
+            vol_transport[:,:,dr_w] = ( velocity[:,:,dr_w] * v_ds.e1.to_masked_array()[dr_w] *
+                                  v_ds.e3.to_masked_array()[:,:,dr_w] )
+            e3[:,:,dr_w] = v_ds.e3.values[:,:,dr_w]
         depth_0[:,dr_w] = v_ds.depth_0.to_masked_array()[:,dr_w]
         latitude[dr_w] = v_ds.latitude.values[dr_w]
         longitude[dr_w] = v_ds.longitude.values[dr_w]
         e1[dr_w] = v_ds.e1.values[dr_w]
         e2[dr_w] = v_ds.e2.values[dr_w]
-        e3_0[:,dr_w] = v_ds.e3_0.values[:,dr_w]
-           
+                   
         # Add DataArrays to dataset 
         if droptime:
             self.data_cross_tran_flow['normal_velocities'] = xr.DataArray( velocity.squeeze(), 
                     coords={'depth_0': (('z_dim','r_dim'), depth_0) 
                             ,'latitude': (('r_dim'), latitude), 'longitude': (('r_dim'), longitude) },
-                    dims=['z_dim', 'r_dim'] )        
-            self.data_cross_tran_flow['normal_transports'] \
+                    dims=['z_dim', 'r_dim'] ) 
+            if compute_transports:
+                self.data_cross_tran_flow['normal_transports'] \
                     = xr.DataArray( np.sum(vol_transport.squeeze(), axis=0) / 1000000., \
                     coords={'latitude': (('r_dim'), latitude), 'longitude': (('r_dim'), longitude)},\
                     dims=['r_dim'] ).squeeze() 
@@ -387,26 +419,29 @@ class Transect_f(Transect):
             self.data_cross_tran_flow['normal_velocities'] = xr.DataArray( velocity, 
                         coords={'time': (('t_dim'), u_ds.time.values),'depth_0': (('z_dim','r_dim'), depth_0)
                                 ,'latitude': (('r_dim'), latitude), 'longitude': (('r_dim'), longitude) },
-                        dims=['t_dim', 'z_dim', 'r_dim'] )            
-            self.data_cross_tran_flow['normal_transports'] \
+                        dims=['t_dim', 'z_dim', 'r_dim'] )   
+            if compute_transports:
+                self.data_cross_tran_flow['normal_transports'] \
                         = xr.DataArray( np.sum(vol_transport, axis=1) / 1000000.,
                         coords={'time': (('t_dim'), u_ds.time.values)
                                 ,'latitude': (('r_dim'), latitude), 'longitude': (('r_dim'), longitude)},
                         dims=['t_dim', 'r_dim'] ).squeeze()          
         self.data_cross_tran_flow['e1'] = xr.DataArray( e1, dims=['r_dim'] ) 
         self.data_cross_tran_flow['e2'] = xr.DataArray( e2, dims=['r_dim'] ) 
-        self.data_cross_tran_flow['e3_0'] = xr.DataArray( e3_0, dims=['z_dim','r_dim'] ) 
+        if compute_transports:
+            self.data_cross_tran_flow['e3'] = xr.DataArray( e3, dims=['t_dim','z_dim','r_dim'] ) 
         # DataArray attributes   
         self.data_cross_tran_flow.normal_velocities.attrs['units'] = 'm/s'
         self.data_cross_tran_flow.normal_velocities.attrs['standard_name'] = 'velocity across the transect'
-        self.data_cross_tran_flow.normal_velocities.attrs['long_name'] = 'velocity across the transect defined on the normal velocity grid points'    
-        self.data_cross_tran_flow.normal_transports.attrs['units'] = 'Sv'
-        self.data_cross_tran_flow.normal_transports.attrs['standard_name'] = 'depth integrated volume transport across transect'
-        self.data_cross_tran_flow.normal_transports.attrs['long_name'] = 'depth integrated volume transport across the transect defined on the normal velocity grid points' 
+        self.data_cross_tran_flow.normal_velocities.attrs['long_name'] = 'velocity across the transect defined on the normal velocity grid points'  
+        if compute_transports:
+            self.data_cross_tran_flow.normal_transports.attrs['units'] = 'Sv'
+            self.data_cross_tran_flow.normal_transports.attrs['standard_name'] = 'depth integrated volume transport across transect'
+            self.data_cross_tran_flow.normal_transports.attrs['long_name'] = 'depth integrated volume transport across the transect defined on the normal velocity grid points' 
         self.data_cross_tran_flow.depth_0.attrs['units'] = 'm'
         self.data_cross_tran_flow.depth_0.attrs['standard_name'] = 'depth'
         self.data_cross_tran_flow.depth_0.attrs['long_name'] = 'Initial depth at time zero defined at the normal velocity grid points'
-                        
+        self.data_cross_tran_flow = self.data_cross_tran_flow.squeeze()
   
     def __pressure_grad_fpoint(self, ds_T, ds_T_j1, ds_T_i1, ds_T_j1i1, r_ind, velocity_component):
         """
@@ -660,7 +695,7 @@ class Transect_f(Transect):
         self.data_cross_tran_flow['normal_velocity_spg'] = xr.DataArray( np.squeeze(normal_velocity_spg),
                 coords=coords_spg, dims=dims_spg, attrs=attributes_spg)
         self.data_cross_tran_flow['normal_transport_hpg'] = ( self.data_cross_tran_flow
-                .normal_velocity_hpg.fillna(0).integrate(dim='depth_z_levels') ) * e_horiz / 1000000   
+                .normal_velocity_hpg.fillna(0).integrate(coord='depth_z_levels') ) * e_horiz / 1000000   
         self.data_cross_tran_flow.normal_transport_hpg.attrs = {'units': 'Sv', 
                 'standard_name': 'volume transport across transect due to the hydrostatic pressure gradient'}        
         self.data_cross_tran_flow['normal_transport_spg'] = self.data_cross_tran_flow.normal_velocity_spg * H * e_horiz / 1000000

--- a/coast/TRANSECT.py
+++ b/coast/TRANSECT.py
@@ -695,7 +695,7 @@ class Transect_f(Transect):
         self.data_cross_tran_flow['normal_velocity_spg'] = xr.DataArray( np.squeeze(normal_velocity_spg),
                 coords=coords_spg, dims=dims_spg, attrs=attributes_spg)
         self.data_cross_tran_flow['normal_transport_hpg'] = ( self.data_cross_tran_flow
-                .normal_velocity_hpg.fillna(0).integrate(coord='depth_z_levels') ) * e_horiz / 1000000   
+                .normal_velocity_hpg.fillna(0).integrate(dim='depth_z_levels') ) * e_horiz / 1000000   
         self.data_cross_tran_flow.normal_transport_hpg.attrs = {'units': 'Sv', 
                 'standard_name': 'volume transport across transect due to the hydrostatic pressure gradient'}        
         self.data_cross_tran_flow['normal_transport_spg'] = self.data_cross_tran_flow.normal_velocity_spg * H * e_horiz / 1000000

--- a/coast/eof.py
+++ b/coast/eof.py
@@ -195,7 +195,7 @@ def _compute(signal, full_matrices, active_ind, number_points):
     '''
     P, D, Q = linalg.svd(signal, full_matrices=full_matrices)   
     mode_count = P.shape[-1]     
-    EOFs = np.zeros( (number_points, mode_count), dtype=P.dtype)
+    EOFs = np.full( (number_points, mode_count), np.nan, dtype=P.dtype)
     EOFs[active_ind,:] = P 
     
     # Calculate variance explained

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 PACKAGE = SimpleNamespace(**{
     "name": "COAsT",
-    "version": "0.3.1a03",
+    "version": "0.3.1a5",
     "description": "This is the Coast Ocean Assessment Tool",
     "url": "https://www.bodc.ac.uk",
     "download_url": "https://github.com/British-Oceanographic-Data-Centre/COAsT/",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 PACKAGE = SimpleNamespace(**{
     "name": "COAsT",
-    "version": "0.3.1a02",
+    "version": "0.3.1a03",
     "description": "This is the Coast Ocean Assessment Tool",
     "url": "https://www.bodc.ac.uk",
     "download_url": "https://github.com/British-Oceanographic-Data-Centre/COAsT/",


### PR DESCRIPTION
This branch has already been merged with branch 109/time_dependent_e3 so i have removed that previous pull request.

This branch is mainly tying up loose ends. Nothing new has been added to the unit testing. 

Changes from branch 109/time_dependent_e3 merged into this branch:
1) adds a static method:
NEMO.get_e3_from_ssh( nemo_t, e3t=True, e3u=False, e3v=False, e3f=False, e3w=False, dom_fn=None )
which computes the time dependent e3[t,u,v,f,w] variables from the SSH (which means the averaging will be based on the SSH averaging) and the domain_cfg data. You tell it which ones you want. My tests show it accurate to about 10^{-5} absolute, which should just be rounding errors. #262 
2) The only other thing touched in the package is to make the 'bottom_level' variable pulled across from the domain_cfg. See item 1k in the unit_test.

Changes in this branch
1) TRANSECT, CONTOUR: The cross-transact and cross-contour flow methods now use the time-dependent e3 variables in their computations rather than the e3_0 variables. If the e3s aren't available it will use the e3_0. #241  
2) TRANSECT, CONTOUR:Added a bit of robustness to both methods in terms of handling special cases
3) NEMO: Added some more variable renaming e.g. soce->salinity, u velocities->u_velocity and v velocities->v_velocity #241 
4) NEMO: Fixed a bug in get_e3_from_ssh() whereby it couldn't handle a nemo_t object that had no time dimension.
5) EOF: fixed a bug where the eof loses the mask of the original data. #236 