### PR TITLE
Feature/bodcdmsys 3699: xarray --> 0.19.0

### DIFF
--- a/coast/COAsT.py
+++ b/coast/COAsT.py
@@ -177,9 +177,9 @@ class COAsT:
         obj_copy.dataset = obj_copy.dataset.sel(indexers, drop, **kwargs)
         return obj_copy
 
-    def rename(self, rename_dict, inplace: bool = None, **kwargs):
+    def rename(self, rename_dict, **kwargs):
         debug(f"Renaming {get_slug(self.dataset)} with dict {rename_dict}")
-        self.dataset = self.dataset.rename(rename_dict, inplace, **kwargs)
+        self.dataset = self.dataset.rename(rename_dict, **kwargs)
         return  # TODO Should this return something? If not, the statement is not needed
 
     def subset(self, **kwargs):

--- a/coast/CONTOUR.py
+++ b/coast/CONTOUR.py
@@ -754,7 +754,7 @@ class Contour_f(Contour):
             np.squeeze(normal_velocity_spg), coords=coords_spg, dims=dims_spg, attrs=attributes_spg
         )
         self.data_cross_flow["transport_across_AB_hpg"] = (
-            (self.data_cross_flow.normal_velocity_hpg.fillna(0).integrate(dim="depth_z_levels")) * e_horiz / 1000000
+            (self.data_cross_flow.normal_velocity_hpg.fillna(0).integrate(coord="depth_z_levels")) * e_horiz / 1000000
         )
         self.data_cross_flow.transport_across_AB_hpg.attrs = {
             "units": "Sv",

--- a/coast/CONTOUR.py
+++ b/coast/CONTOUR.py
@@ -719,8 +719,8 @@ class Contour_f(Contour):
         # DataArray attributes
         coords_hpg = {
             "depth_z_levels": (("depth_z_levels"), z_levels),
-            "latitude": (("r_dim"), self.data_cross_flow.latitude),
-            "longitude": (("r_dim"), self.data_cross_flow.longitude),
+            "latitude": (("r_dim"), self.data_cross_flow.latitude.values),
+            "longitude": (("r_dim"), self.data_cross_flow.longitude.values),
         }
         dims_hpg = ["depth_z_levels", "r_dim"]
         attributes_hpg = {
@@ -729,8 +729,8 @@ class Contour_f(Contour):
                           transect due to the hydrostatic pressure gradient",
         }
         coords_spg = {
-            "latitude": (("r_dim"), self.data_cross_flow.latitude),
-            "longitude": (("r_dim"), self.data_cross_flow.longitude),
+            "latitude": (("r_dim"), self.data_cross_flow.latitude.values),
+            "longitude": (("r_dim"), self.data_cross_flow.longitude.values),
         }
         dims_spg = ["r_dim"]
         attributes_spg = {
@@ -741,9 +741,9 @@ class Contour_f(Contour):
 
         # Add time if required
         if "t_dim" in cont_t.data_contour.dims:
-            coords_hpg["time"] = (("t_dim"), cont_t.data_contour.time)
+            coords_hpg["time"] = (("t_dim"), cont_t.data_contour.time.values)
             dims_hpg.insert(0, "t_dim")
-            coords_spg["time"] = (("t_dim"), cont_t.data_contour.time)
+            coords_spg["time"] = (("t_dim"), cont_t.data_contour.time.values)
             dims_spg.insert(0, "t_dim")
 
         # Add DataArrays  to dataset
@@ -898,8 +898,8 @@ class Contour_t(Contour):
 
         coords = {
             "depth_z_levels": (("depth_z_levels"), z_levels),
-            "latitude": (("r_dim"), self.data_contour.latitude),
-            "longitude": (("r_dim"), self.data_contour.longitude),
+            "latitude": (("r_dim"), self.data_contour.latitude.values),
+            "longitude": (("r_dim"), self.data_contour.longitude.values),
         }
         dims = ["depth_z_levels", "r_dim"]
         attributes = {"units": "kg / m^3", "standard name": "In-situ density on the z-level vertical grid"}

--- a/coast/TIDEGAUGE.py
+++ b/coast/TIDEGAUGE.py
@@ -1278,10 +1278,10 @@ class TIDEGAUGE:
 
         new_dataset = xr.Dataset()
         new_dataset.attrs = self.dataset.attrs
-        new_dataset[var_str + "_highs"] = ("time_highs", values_max)
-        new_dataset[var_str + "_lows"] = ("time_lows", -values_min)
-        new_dataset["time_highs"] = ("time_highs", time_max)
-        new_dataset["time_lows"] = ("time_lows", time_min)
+        new_dataset[var_str + "_highs"] = ("time_highs", values_max.values)
+        new_dataset[var_str + "_lows"] = ("time_lows", -values_min.values)
+        new_dataset["time_highs"] = ("time_highs", time_max.values)
+        new_dataset["time_lows"] = ("time_lows", time_min.values)
 
         new_object = TIDEGAUGE()
         new_object.dataset = new_dataset

--- a/coast/TRANSECT.py
+++ b/coast/TRANSECT.py
@@ -748,9 +748,9 @@ class Transect_f(Transect):
 
         # Add time if required
         if "t_dim" in tran_t.data.dims:
-            coords_hpg["time"] = (("t_dim"), tran_t.data.time)
+            coords_hpg["time"] = (("t_dim"), tran_t.data.time.values)
             dims_hpg.insert(0, "t_dim")
-            coords_spg["time"] = (("t_dim"), tran_t.data.time)
+            coords_spg["time"] = (("t_dim"), tran_t.data.time.values)
             dims_spg.insert(0, "t_dim")
 
         # Add DataArrays  to dataset
@@ -1021,8 +1021,8 @@ class Transect_t(Transect):
 
         coords = {
             "depth_z_levels": (("depth_z_levels"), z_levels),
-            "latitude": (("r_dim"), self.data.latitude),
-            "longitude": (("r_dim"), self.data.longitude),
+            "latitude": (("r_dim"), self.data.latitude.values),
+            "longitude": (("r_dim"), self.data.longitude.values),
         }
         dims = ["depth_z_levels", "r_dim"]
         attributes = {"units": "kg / m^3", "standard name": "In-situ density on the z-level vertical grid"}

--- a/coast/TRANSECT.py
+++ b/coast/TRANSECT.py
@@ -761,7 +761,7 @@ class Transect_f(Transect):
             np.squeeze(normal_velocity_spg), coords=coords_spg, dims=dims_spg, attrs=attributes_spg
         )
         self.data_cross_tran_flow["normal_transport_hpg"] = (
-            (self.data_cross_tran_flow.normal_velocity_hpg.fillna(0).integrate(dim="depth_z_levels"))
+            (self.data_cross_tran_flow.normal_velocity_hpg.fillna(0).integrate(coord="depth_z_levels"))
             * e_horiz
             / 1000000
         )

--- a/coast/eof.py
+++ b/coast/eof.py
@@ -58,10 +58,10 @@ def eofs(variable: xr.DataArray, full_matrices: bool = False, time_dim_name: str
     time_coords = {"mode": (("mode"), np.arange(1, mode_count + 1))}
     for coord in variable.coords:
         if variable.dims[2] not in variable[coord].dims:
-            coords[coord] = (variable[coord].dims, variable[coord])
+            coords[coord] = (variable[coord].dims, variable[coord].values)
         else:
             if (variable.dims[2],) == variable[coord].dims:
-                time_coords[coord] = (variable[coord].dims, variable[coord])
+                time_coords[coord] = (variable[coord].dims, variable[coord].values)
 
     dataset = xr.Dataset()
 
@@ -146,10 +146,10 @@ def hilbert_eofs(variable: xr.DataArray, full_matrices=False, time_dim_name: str
     time_coords = {"mode": (("mode"), np.arange(1, mode_count + 1))}
     for coord in variable.coords:
         if variable.dims[2] not in variable[coord].dims:
-            coords[coord] = (variable[coord].dims, variable[coord])
+            coords[coord] = (variable[coord].dims, variable[coord].values)
         else:
             if (variable.dims[2],) == variable[coord].dims:
-                time_coords[coord] = (variable[coord].dims, variable[coord])
+                time_coords[coord] = (variable[coord].dims, variable[coord].values)
 
     dims = (variable.dims[:2]) + ("mode",)
     dataset["EOF_amp"] = xr.DataArray(EOF_amp, coords=coords, dims=dims)

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16
 dask>=2
 dask[complete]>=2
-xarray>=0.19
+xarray~=0.19.0
 matplotlib==3.2.1
 netCDF4>=1
 scipy>=1

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.16
 dask>=2
 dask[complete]>=2
-xarray>=0.15
+xarray>=0.19
 matplotlib==3.2.1
 netCDF4>=1
 scipy>=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest==6.0.2
 numpy>=1.16
 dask>=2
 dask[complete]>=2
-xarray>=0.19
+xarray~=0.19.0
 matplotlib==3.2.1
 netCDF4>=1
 scipy>=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest==6.0.2
 numpy>=1.16
 dask>=2
 dask[complete]>=2
-xarray>=0.15
+xarray>=0.19
 matplotlib==3.2.1
 netCDF4>=1
 scipy>=1


### PR DESCRIPTION
Depreciations in updating xarray to 0.19.0 fixed:

* xarray rename() method no longer takes 'inplace'
* xr.integrate() operates over coords, no longer dim 
* coords can not longer be xr obj when creating a new xr obj 

Also:

* Updated conda_requirements.txt & requirements.txt <-- xarray 0.19.0 
* Updated Getting_Started docsy site <-- xarray 0.19.0 (on [branch](https://github.com/British-Oceanographic-Data-Centre/COAsT-site/blob/feature/getting_started/content/en/docs/Getting%20started/_index.md))

AC:
* unit_testing works (having updated python environment following  [e.g. Getting Started](https://github.com/British-Oceanographic-Data-Centre/COAsT-site/blob/feature/getting_started/content/en/docs/Getting%20started/_index.md). `unit_test2.py` works for me.
* Nothing (too) bad has happened to lazy loading?
* @anwiseNOCL  is happy with contour.py,  eof.py, transect.py edits.
* @davbyr is happy with tidegauge.py edit
* Edits to docsy are OK to go.
