### PR TITLE
reintroduce working unit_test

### DIFF
--- a/unit_testing/unit_test.py
+++ b/unit_testing/unit_test.py
@@ -58,7 +58,7 @@ tests_to_do = [
     test_climatology,
     test_wod_read_data,
     test_bgc_gridded_initialisation,
-    # test_process_data_methods,
+    test_process_data_methods,
     # test_example_scripts,
 ]
 


### PR DESCRIPTION
`test_process_data_methods` worked. Reintroduced.
`test_example_scripts` will not be introduced as we are devising new ways to handle these.

AC:
unit_testing works