### PR TITLE
Correct directory oversight in doc builder

### DIFF
--- a/markdown_doc_builder.py
+++ b/markdown_doc_builder.py
@@ -23,7 +23,7 @@ class MarkdownBuilder:
     @property
     def directory(self) -> Path:
         """Make sure we have a markdown folder to write to."""
-        (directory := Path("markdown").resolve(strict=True)).mkdir(exist_ok=True)
+        (directory := Path("markdown").resolve(strict=False)).mkdir(exist_ok=True, parents=True)
         return directory
 
     @property


### PR DESCRIPTION
Fix an oversight on my part - disable strict resolve (directory probably doesn't exist yet) and enable creating of parent directories.