### PR TITLE
update read_bodc dimension to include id_dim

### DIFF
--- a/coast/data/tidegauge.py
+++ b/coast/data/tidegauge.py
@@ -835,13 +835,18 @@ class Tidegauge(Timeseries):
         except:
             raise Exception("Problem reading BODC file: " + fn_bodc)
         # Attributes
-        dataset["longitude"] = header_dict["longitude"]
-        dataset["latitude"] = header_dict["latitude"]
+        dataset["longitude"] = ("id_dim", [header_dict["longitude"]])
+        dataset["latitude"] = ("id_dim", [header_dict["latitude"]])
+        dataset["id_name"] = ("id_dim", [header_dict["site_name"]])
+        dataset = dataset.set_coords(["longitude", "latitude", "id_name"])
+
         del header_dict["longitude"]
         del header_dict["latitude"]
+        del header_dict["site_name"]
 
         dataset.attrs = header_dict
         self.dataset = dataset
+        self.apply_config_mappings()
 
     @staticmethod
     def _read_bodc_header(fn_bodc):


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
    - Some docs updates need to be made in the `COAsT-site` repo, in a separate PR. See [contributing to documentation ](https://british-oceanographic-data-centre.github.io/COAsT/docs/contributing-docs/) for details.
- [ ] Build (`./build.sh`) was run locally and no errors reported. NB not sure about this requirement: GitActions test this
- [ ] Lint (`pylint .`) has passed locally and any fixes were made for failures. NB not sure about this requirement: GitActions test this with `black`


## Pull request type

Update read_bodc method to include awareness of id_dim
Make these data loads consistent with data objects from read_gesla.


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
Error when trying to use obs_operator() on data object generated with tidegauge.read_bodc()
Method is missing latitude and longitude coords. (There are in attributes)

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #


## What is the new behavior?
No error when trying to use obs_operator() on data object generated with tidegauge.read_bodc()
Lat and lon are now coordinates and not attributes.

-
-
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`pip install . && pytest unit_testing/unit_test.py -s`)
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


