### PR TITLE
remove deprec warning

### DIFF
--- a/coast/_utils/stats_util.py
+++ b/coast/_utils/stats_util.py
@@ -67,24 +67,22 @@ def find_maxima(x, y, method="comp", **kwargs):
         return x[peaks], y[peaks]
 
     if method == "cubic":
-        """
-        Cleverness found at
-        https://stackoverflow.com/questions/50371298/find-maximum-minimum-of-a-1d-interpolated-function
+        # Cleverness found at
+        # https://stackoverflow.com/questions/50371298/find-maximum-minimum-of-a-1d-interpolated-function
 
-        Find the extrema on a cubic spline fitted to 1d array. E.g:
-        # Some data
-        x_axis = xr.DataArray([ 2.14414414,  2.15270826,  2.16127238,  2.1698365 ,  2.17840062, 2.18696474,  2.19552886,  2.20409298,  2.2126571 ,  2.22122122])
-        y_axis = xr.DataArray([ 0.67958442,  0.89628424,  0.78904004,  3.93404167,  6.46422317, 6.40459954,  3.80216674,  0.69641825,  0.89675386,  0.64274198])
-        # Fit cubic spline
-        f = scipy.interpolate.interp1d(x_axis, y_axis, kind = 'cubic')
-        x_new = np.linspace(x_axis[0], x_axis[-1],100)
-        cr_pts, cr_vals = stats_utils.find_maxima(x_axis, y_axis, method='cubic')
-        fig = plt.subplots()
-        plt.plot(x_axis, y_axis, 'r+') # The fitted spline
-        plt.plot(x_new, f(x_new)) # The fitted spline
-        plt.plot(cr_pts, cr_vals, 'o') # The extrema
+        # Find the extrema on a cubic spline fitted to 1d array. E.g:
+        # # Some data
+        # x_axis = xr.DataArray([ 2.14414414,  2.15270826,  2.16127238,  2.1698365 ,  2.17840062, 2.18696474,  2.19552886,  2.20409298,  2.2126571 ,  2.22122122])
+        # y_axis = xr.DataArray([ 0.67958442,  0.89628424,  0.78904004,  3.93404167,  6.46422317, 6.40459954,  3.80216674,  0.69641825,  0.89675386,  0.64274198])
+        # # Fit cubic spline
+        # f = scipy.interpolate.interp1d(x_axis, y_axis, kind = 'cubic')
+        # x_new = np.linspace(x_axis[0], x_axis[-1],100)
+        # cr_pts, cr_vals = stats_utils.find_maxima(x_axis, y_axis, method='cubic')
+        # fig = plt.subplots()
+        # plt.plot(x_axis, y_axis, 'r+') # The fitted spline
+        # plt.plot(x_new, f(x_new)) # The fitted spline
+        # plt.plot(cr_pts, cr_vals, 'o') # The extrema
 
-        """
         # Remove NaNs
         nan_mask = np.isnan(y)
         if sum(nan_mask) > 0:

--- a/coast/data/tidegauge.py
+++ b/coast/data/tidegauge.py
@@ -537,12 +537,13 @@ class Tidegauge(Timeseries):
                         datetime_obj = datetime.datetime.strptime(time_str, "%d/%m/%Y %H:%M")
                         if localtime_flag is True:
                             bst_obj = pytz.timezone("Europe/London")
-                            time.append(np.datetime64(bst_obj.localize(datetime_obj).
-                                                      astimezone(pytz.utc).
-                                                      replace(tzinfo=None)).
-                                        astype('datetime64[ns]'))
+                            time.append(
+                                np.datetime64(
+                                    bst_obj.localize(datetime_obj).astimezone(pytz.utc).replace(tzinfo=None)
+                                ).astype("datetime64[ns]")
+                            )
                         else:
-                            time.append(np.datetime64(datetime_obj).astype('datetime64[ns]'))
+                            time.append(np.datetime64(datetime_obj).astype("datetime64[ns]"))
                         ssh.append(float(working_line[2]))
                 line_count = line_count + 1
             debug(f'Read done, close file "{filnam}"')
@@ -574,7 +575,7 @@ class Tidegauge(Timeseries):
         Print out the values in the xarray
         Displays with specified timezone
         """
-        # debug(" Saltney pred", 
+        # debug(" Saltney pred",
         #       np.datetime_as_string(Saltney_time_pred[i],
         #                             unit='m',
         #                             timezone=pytz.timezone('Europe/London')),
@@ -596,9 +597,7 @@ class Tidegauge(Timeseries):
                 debug(
                     "time (" + timezone + "):",
                     general_utils.day_of_week(self.dataset.time[idx].values),
-                    np.datetime_as_string(self.dataset.time[idx], 
-                                          unit="m",
-                                          timezone=pytz.timezone(timezone)),
+                    np.datetime_as_string(self.dataset.time[idx], unit="m", timezone=pytz.timezone(timezone)),
                     "height:",
                     ssh.values,
                     "m",

--- a/coast/data/tidegauge.py
+++ b/coast/data/tidegauge.py
@@ -524,7 +524,7 @@ class Tidegauge(Timeseries):
             localtime_flag = False
 
         # Open file and loop until EOF
-        with open(filnam) as file:
+        with open(filnam, encoding="utf-8") as file:
             line_count = 1
             for line in file:
                 # Read all data. Date boundaries are set later.
@@ -532,13 +532,17 @@ class Tidegauge(Timeseries):
                     working_line = line.split()
                     if working_line[0] != "#":
                         time_str = working_line[0] + " " + working_line[1]
-                        # Read time as datetime.datetime because it can handle local timezone easily AND the unusual date format
+                        # Read time as datetime.datetime because it can handle
+                        # local timezone easily AND the unusual date format
                         datetime_obj = datetime.datetime.strptime(time_str, "%d/%m/%Y %H:%M")
-                        if localtime_flag == True:
+                        if localtime_flag is True:
                             bst_obj = pytz.timezone("Europe/London")
-                            time.append(np.datetime64(bst_obj.localize(datetime_obj).astimezone(pytz.utc)))
+                            time.append(np.datetime64(bst_obj.localize(datetime_obj).
+                                                      astimezone(pytz.utc).
+                                                      replace(tzinfo=None)).
+                                        astype('datetime64[ns]'))
                         else:
-                            time.append(np.datetime64(datetime_obj))
+                            time.append(np.datetime64(datetime_obj).astype('datetime64[ns]'))
                         ssh.append(float(working_line[2]))
                 line_count = line_count + 1
             debug(f'Read done, close file "{filnam}"')
@@ -570,27 +574,33 @@ class Tidegauge(Timeseries):
         Print out the values in the xarray
         Displays with specified timezone
         """
-        # debug(" Saltney pred", np.datetime_as_string(Saltney_time_pred[i], unit='m', timezone=pytz.timezone('Europe/London')),". Height: {:.2f} m".format( HT.values[i] ))
-        if timezone == None:
-            for i in range(len(self.dataset.ssh)):
-                #               debug('time:', self.dataset.time[i].values,
+        # debug(" Saltney pred", 
+        #       np.datetime_as_string(Saltney_time_pred[i],
+        #                             unit='m',
+        #                             timezone=pytz.timezone('Europe/London')),
+        #       ". Height: {:.2f} m".format( HT.values[i] ))
+        if timezone is None:
+            for ssh, idx in enumerate(self.dataset.ssh):
+                # debug('time:', self.dataset.time[i].values,
                 debug(
                     "time (UTC):",
-                    general_utils.dayoweek(self.dataset.time[i].values),
-                    np.datetime_as_string(self.dataset.time[i], unit="m"),
+                    general_utils.dayoweek(self.dataset.time[idx].values),
+                    np.datetime_as_string(self.dataset.time[idx], unit="m"),
                     "height:",
-                    self.dataset.ssh[i].values,
+                    ssh.values,
                     "m",
                 )
         else:  # display timezone aware times
-            for i in range(len(self.dataset.ssh)):
-                #               debug('time:', self.dataset.time[i].values,
+            for ssh, idx in enumerate(self.dataset.ssh):
+                # debug('time:', self.dataset.time[i].values,
                 debug(
                     "time (" + timezone + "):",
-                    general_utils.day_of_week(self.dataset.time[i].values),
-                    np.datetime_as_string(self.dataset.time[i], unit="m", timezone=pytz.timezone(timezone)),
+                    general_utils.day_of_week(self.dataset.time[idx].values),
+                    np.datetime_as_string(self.dataset.time[idx], 
+                                          unit="m",
+                                          timezone=pytz.timezone(timezone)),
                     "height:",
-                    self.dataset.ssh[i].values,
+                    ssh.values,
                     "m",
                 )
 
@@ -614,8 +624,10 @@ class Tidegauge(Timeseries):
             window:  +/- hours window size, winsize, (int) return values in that window
                 uses additional variable winsize (int) [default 2hrs]
             nearest_1: return only the nearest event, if in winsize [default:None]
-            nearest_2: return nearest event in future and the nearest in the past (i.e. high and a low), if in winsize [default:None]
-            nearest_HW: return nearest High Water event (computed as the max of `nearest_2`), if in winsize [default:None]
+            nearest_2: return nearest event in future and the nearest in the past
+        (i.e. high and a low), if in winsize [default:None]
+            nearest_HW: return nearest High Water event (computed as the max of
+        `nearest_2`), if in winsize [default:None]
 
         returns: xr.DataArray( measure_var, coords=time_var)
             E.g. ssh (m), time (utc)
@@ -628,12 +640,12 @@ class Tidegauge(Timeseries):
             debug("Convert date to np.datetime64")
             time_guess = np.datetime64(time_guess)
 
-        if time_guess == None:
+        if time_guess is None:
             debug("Use today's date")
             time_guess = np.datetime64("now")
 
         if method == "window":
-            if winsize == None:
+            if winsize is None:
                 winsize = 2
             # initialise start_index and end_index
             start_index = 0

--- a/coast/diagnostics/circulation.py
+++ b/coast/diagnostics/circulation.py
@@ -101,7 +101,8 @@ class CurrentsOnT(Gridded):
         magnitude: shaded
         """
         # %%
-        from matplotlib import cm
+        import matplotlib.pyplot as plt
+
         from matplotlib.colors import LinearSegmentedColormap
 
         nx = self.dataset.x_dim.size
@@ -124,9 +125,11 @@ class CurrentsOnT(Gridded):
         X = self.dataset.longitude
         Y = self.dataset.latitude
         # create a light colour map
-        N_colours = int(Vmax * 100)
+        n_colours = int(Vmax * 100)
         n_c = 2
-        cmap0 = cm.get_cmap("BrBG_r", lut=N_colours + n_c * 2)
+        cmap = plt.get_cmap("BrBG")
+        n_colors = n_colours + n_c * 2  # Define the total number of colors you want
+        cmap0 = plt.cm.colors.ListedColormap(cmap(range(n_colors - 1, -1, -1)))
         colors = cmap0(np.arange(cmap0.N))
         colors1 = colors[n_c : cmap0.N - n_c]
         cmap1 = LinearSegmentedColormap.from_list("cmap1", colors1, cmap0.N - n_c * 2)

--- a/unit_testing/test_general_utils.py
+++ b/unit_testing/test_general_utils.py
@@ -39,13 +39,10 @@ class test_general_utils(unittest.TestCase):
     def test_bst_to_gmt(self):
         time_str = "11/10/2020 12:00"
         datetime_obj = datetime.datetime.strptime(time_str, "%d/%m/%Y %H:%M")
-        bst_obj = pytz.timezone("Europe/London")      
+        bst_obj = pytz.timezone("Europe/London")
         check1 = np.datetime64(
-            bst_obj.localize(datetime_obj).
-            astimezone(pytz.utc).
-            replace(tzinfo=None)) == np.datetime64(
-            "2020-10-11T11:00:00"
-        )
+            bst_obj.localize(datetime_obj).astimezone(pytz.utc).replace(tzinfo=None)
+        ) == np.datetime64("2020-10-11T11:00:00")
         self.assertTrue(check1, msg="check1")
 
     def test_nan_helper(self):

--- a/unit_testing/test_general_utils.py
+++ b/unit_testing/test_general_utils.py
@@ -39,8 +39,11 @@ class test_general_utils(unittest.TestCase):
     def test_bst_to_gmt(self):
         time_str = "11/10/2020 12:00"
         datetime_obj = datetime.datetime.strptime(time_str, "%d/%m/%Y %H:%M")
-        bst_obj = pytz.timezone("Europe/London")
-        check1 = np.datetime64(bst_obj.localize(datetime_obj).astimezone(pytz.utc)) == np.datetime64(
+        bst_obj = pytz.timezone("Europe/London")      
+        check1 = np.datetime64(
+            bst_obj.localize(datetime_obj).
+            astimezone(pytz.utc).
+            replace(tzinfo=None)) == np.datetime64(
             "2020-10-11T11:00:00"
         )
         self.assertTrue(check1, msg="check1")


### PR DESCRIPTION
After updating the Python version, there were still some deprecation warnings present in the code. I successfully addressed and resolved all of the warnings associated with the COAsT code. However, there remain certain warnings related to the xarray and utide libraries, which cannot be eliminated since they pertain to dependencies. I also chose to retain one warning labeled as "Pending" because I believe it may only become relevant in the distant future.