### PR TITLE
Minor easing for GESLAv5 read in. Added time variable filtering for profile analysis means.

### DIFF
--- a/coast/data/tidegauge.py
+++ b/coast/data/tidegauge.py
@@ -240,7 +240,7 @@ class Tidegauge(Timeseries):
             datum = " ".join(datum)
             instrument = fid.readline().split()[2:]
             instrument = " ".join(instrument)
-            precision = float(fid.readline().split()[2])
+            precision = fid.readline().split()[2]
             null_value = float(fid.readline().split()[3])
             gauge_type = fid.readline().split()[3:]
             gauge_type = " ".join(gauge_type)

--- a/coast/diagnostics/profile_analysis.py
+++ b/coast/diagnostics/profile_analysis.py
@@ -39,7 +39,7 @@ class ProfileAnalysis(Indexed):
         var_list = list(dataset.keys())
         time_var_list = ["time"]
         for vv in var_list:
-            if dataset[vv].dtype in ["M8[ns]", "timedelta64[ns]"]:
+            if dataset[vv].dtype in ["M8[ns]", "timedelta64[ns]", "timedelta64[s]"]:
                 time_var_list.append(vv)
 
         # Extract/remove time vars from input dataset (but save them)
@@ -107,7 +107,7 @@ class ProfileAnalysis(Indexed):
         var_list = list(dataset.keys())
         time_var_list = ["time"]
         for vv in var_list:
-            if dataset[vv].dtype in ["M8[ns]", "timedelta64[ns]"]:
+            if dataset[vv].dtype in ["M8[ns]", "timedelta64[ns]", "timedelta64[s]"]:
                 time_var_list.append(vv)
 
         # Remove the time variables and save them for merge back later


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help:  https://british-oceanographic-data-centre.github.io/COAsT/docs/contributing_package/ -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
    - Some docs updates need to be made in the `COAsT-site` repo, in a separate PR. See [contributing to documentation ](https://british-oceanographic-data-centre.github.io/COAsT/docs/contributing-docs/) for details.
- [ ] Build (`./build.sh`) was run locally and no errors reported. NB not sure about this requirement: GitActions test this
- [ ] Lint (`pylint .`) has passed locally and any fixes were made for failures. NB not sure about this requirement: GitActions test this with `black`

Unsure how to run these tests. 

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
1. Regional profile analysis (depth_means and bottom_means) can fail when dataset contains interval variable with dtype timedelta[s]. 
2. Fails to read in GESLA files when precision is non-integer e.g. 'Empty'.

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
-depth_means and bottom_means will now additionally filter out variables with dtype "timedelta64[s]" .
-read_gesla_header_v5 will read precision as a string.
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing (`pip install . && pytest unit_testing/unit_test.py -s`) 
Note: fails 4 tests: test_gridded_initialisation, test_general_utils, test_altimetry_methods, test_tidegauge_methods. However I get the same 4 failures when running tests with COAsT version 3.3.0.
- [x] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
