### PR TITLE
Fix for transect.py where latitude points decrease with y index

### DIFF
--- a/coast/diagnostics/transect.py
+++ b/coast/diagnostics/transect.py
@@ -128,8 +128,8 @@ class Transect:
                 tran_y_ind, tran_x_ind = self.process_transect_indices(
                     gridded, np.asarray(tran_y_ind), np.asarray(tran_x_ind)
                 )
-            elif y_indices is not None and x_indices is not None:
-                if y_indices[0] > y_indices[-1]:
+            elif y_indices is not None and x_indices is not None: # y_indices increasing != latitude increasing near N pole
+                if gridded.dataset.latitude[y_indices[0], x_indices[0]] > gridded.dataset.latitude[y_indices[-1], x_indices[-1]]:
                     y_indices = y_indices[::-1]
                     x_indices = x_indices[::-1]
                 tran_y_ind, tran_x_ind = self.process_transect_indices(gridded, y_indices, x_indices)
@@ -367,6 +367,8 @@ class TransectF(Transect):
         # directions are positive.
         dr_n = np.where(np.diff(self.y_ind) > 0, np.arange(0, self.data.r_dim.size - 1), np.nan)
         dr_n = dr_n[~np.isnan(dr_n)].astype(int)
+        dr_s = np.where(np.diff(self.y_ind) < 0, np.arange(0, self.data.r_dim.size - 1), np.nan)
+        dr_s = dr_s[~np.isnan(dr_s)].astype(int)
         dr_e = np.where(np.diff(self.x_ind) > 0, np.arange(0, self.data.r_dim.size - 1), np.nan)
         dr_e = dr_e[~np.isnan(dr_e)].astype(int)
         dr_w = np.where(np.diff(self.x_ind) < 0, np.arange(0, self.data.r_dim.size - 1), np.nan)
@@ -384,6 +386,20 @@ class TransectF(Transect):
         longitude[dr_n] = u_ds.longitude.values[dr_n + 1]
         e1[dr_n] = u_ds.e1.values[dr_n + 1]
         e2[dr_n] = u_ds.e2.values[dr_n + 1]
+
+        # u flux (- in)
+        velocity[:, :, dr_s] = -u_ds.u_velocity.to_masked_array()[:, :, dr_s]
+        if compute_transports:
+            vol_transport[:, :, dr_s] = (
+                velocity[:, :, dr_s] * u_ds.e2.to_masked_array()[dr_s] * u_ds.e3.to_masked_array()[:, :, dr_s]
+            )
+            e3[:, :, dr_s] = u_ds.e3.values[:, :, dr_s]
+        depth_0[:, dr_s] = u_ds.depth_0.to_masked_array()[:, dr_s]
+        latitude[dr_s] = u_ds.latitude.values[dr_s]
+        longitude[dr_s] = u_ds.longitude.values[dr_s]
+        e1[dr_s] = u_ds.e1.values[dr_s]
+        e2[dr_s] = u_ds.e2.values[dr_s]
+
 
         # v flux (- in)
         velocity[:, :, dr_e] = -v_ds.v_velocity.to_masked_array()[:, :, dr_e + 1]


### PR DESCRIPTION
Two changes in transect.py: Changed initial check on indices to check latitude instead. Added calculation of negative u-flux for points which have y ind decreasing as latitude increase

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help:  https://british-oceanographic-data-centre.github.io/COAsT/docs/contributing_package/ -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
    - Some docs updates need to be made in the `COAsT-site` repo, in a separate PR. See [contributing to documentation ](https://british-oceanographic-data-centre.github.io/COAsT/docs/contributing-docs/) for details.
- [ ] Build (`./build.sh`) was run locally and no errors reported. NB not sure about this requirement: GitActions test this
- [ ] Lint (`pylint .`) has passed locally and any fixes were made for failures. NB not sure about this requirement: GitActions test this with `black`


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
Two related bugs.

1. Currently, in `transect.__init__`
- If a transect is defined by coords, checks if the coords are ordered S to N
- If a transect is defined by indices, checks if the indices are increasing
These are **not** equivalent in some domains, where latitudes **decrease** with y index, e.g.:
<img width="558" height="454" alt="deltalat" src="https://github.com/user-attachments/assets/9064b44b-e8d8-48fb-9a0f-5f26c31e6ac2" />

2. Currently, in `transect.calc_flow_across_transect`, flow across for E, W and N segments are calculated. However, we need to include S segments, due to the above - this is illustrated for Fram Strait below, where the red segments indicate segments where the latitude **decreases** with y-index, although the whole transect is ordered S->N (right to left in both subplots). This results in a significant error in the transports returned for Fram Strait.
  
<img width="840" height="449" alt="framstrait" src="https://github.com/user-attachments/assets/18c330c7-4dc0-48a0-a8ed-6b4db8d6d6b8" />

<!-- Issues are required for both bug fixes and features. -->
Issue URL: #

## What is the new behavior?

- `transect.__init__` now checks for increasing latitude, **not** increasing index, if transects are defined by indices.
- `transect.calc_flow_across_transect` now includes contributions for S segments, consistent with the definition of other segments. 
These changes result in accurate transports compared with other estimates for Fram Strait.

### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing (`pip install . && pytest unit_testing/unit_test.py -s`)
- [ ] Extended the README / documentation, if necessary
- [ ] Added myself / the copyright holder to the AUTHORS file

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
